### PR TITLE
Fix: posicionamiento Logo en NavBar (desktop)

### DIFF
--- a/src/components/atoms/Logo.vue
+++ b/src/components/atoms/Logo.vue
@@ -9,7 +9,9 @@
 
 <style scoped>
 .navbar-icon {
-  width: 42px;
-  height: 42px;
+  width: 36px;
+  height: 36px;
+  /* needed to align the logo in the navbar */
+  margin-top: 6px;
 }
 </style>


### PR DESCRIPTION
Corregido el estilo del Logo, quedaba demasiado grande y no estaba alineado con los links de navegación en el NavBar en desktop.

Closes #45 