### PR TITLE
Fix: Deshabilitar mock de la API

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,6 +1,7 @@
 // <reference types="vite/client" />
 interface ImportMetaEnv {
-  VITE_API_BASE_URL: string
+  VITE_API_BASE_URL: string,
+  VITE_API_HEALTH_BASE_URL: string,
 }
 
 interface ImportMeta {

--- a/src/composables/useCheckDbHealth.ts
+++ b/src/composables/useCheckDbHealth.ts
@@ -1,9 +1,8 @@
 import { ref } from "vue";
 
 export function useCheckDbHealth() {
-  const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+  const BASE_URL = import.meta.env.VITE_API_HEALTH_BASE_URL;
   const uri = BASE_URL + "/health";
-  // const uri = BASE_URL + "/health?status=error";
   
   const statusMessage = ref("");
   const color = ref("info");

--- a/src/main.js
+++ b/src/main.js
@@ -112,11 +112,15 @@ const vuetify = createVuetify({
 
 // Mock API
 async function prepareApp() {
-  if(import.meta.env.DEV) {
+  const SHOULD_MOCK = import.meta.env.VITE_MOCK_API === "true";
+
+  if(SHOULD_MOCK) {
     const { worker } = await import("./mocks/browser");
+    console.log("start mock")
     return worker.start();
   }
 
+  console.log("Conectando a la API");
   return Promise.resolve();
 }
 


### PR DESCRIPTION
Refactor de la función de prepareApp() para que el mock de la API se pueda activar y desactivar cambiando una variable de entorno.
Creada nueva PR que la anterior traía el commit de prueba de rovo dev. 