### PR TITLE
Fix: visualización error en BoardGamesView

### DIFF
--- a/src/views/BoardGames/BoardGamesView.vue
+++ b/src/views/BoardGames/BoardGamesView.vue
@@ -9,7 +9,7 @@ defineOptions({ name: "BoardGamesView" });
 
 const isSnackBarVisible = true;
 
-const { collection, totalBoardgames, loading: loadingList, errorFetchCollection, fetchCollections } = useCollectionsApi();
+const { collection, totalBoardgames, loading: loadingList, errorFetchCollections, fetchCollections } = useCollectionsApi();
 
 onBeforeMount(async ()=> {
   await fetchCollections();
@@ -23,12 +23,12 @@ onBeforeMount(async ()=> {
     <h1>Ludoteca</h1>
 
     <!-- error on the boardgames list initial fetch -->
-    <v-row v-if="errorFetchCollection">
+    <v-row v-if="errorFetchCollections">
       <v-col>
         <v-alert
           color="error"
           title="¡Oh, no! Ocurrió un error"
-          :text="errorFetchCollection"
+          :text="errorFetchCollections"
         ></v-alert>
       </v-col>
     </v-row>


### PR DESCRIPTION
Cuando había un error con el composable useCollectionsApi en BoardGamesView, no se visualizaban.
Estaba mal el nombre de la variable en la vista. 

Closes #116 