### PR TITLE
Style: Fix issues con padding en bottom-sheets 

### DIFF
--- a/src/components/organisms/AddPlayerSheet.vue
+++ b/src/components/organisms/AddPlayerSheet.vue
@@ -60,7 +60,7 @@ defineExpose({
     data-testid="bottom-sheet"
   >
     <v-sheet color="surface">
-      <v-container class="container">
+      <v-container class="bottom-sheet-container">
         <SubsectionTitle class="title">{{ AddPlayerSheetText.title }}</SubsectionTitle>
         <form @submit.prevent="submitForm">
           <v-text-field 
@@ -103,10 +103,6 @@ defineExpose({
 .title {
   margin-top: 0 !important;
   margin-bottom: 16px !important;
-}
-
-.container {
-  padding: 36px 24px;
 }
 
 .sheet-buttons {

--- a/src/components/organisms/EditPlayerSheet.vue
+++ b/src/components/organisms/EditPlayerSheet.vue
@@ -86,7 +86,7 @@ defineExpose({
     data-testid="bottom-sheet"
   >
     <v-sheet color="surface">
-      <v-container class="container">
+      <v-container class="bottom-sheet-container">
         <SubsectionTitle class="title">{{ EditPlayerSheetText.title }}</SubsectionTitle>
         <form @submit.prevent="submitForm">
           <v-text-field 
@@ -130,10 +130,6 @@ defineExpose({
 .title {
   margin-top: 0 !important;
   margin-bottom: 16px !important;
-}
-
-.container {
-  padding: 36px 24px;
 }
 
 .sheet-buttons {

--- a/src/style.css
+++ b/src/style.css
@@ -166,3 +166,8 @@ button.v-btn {
 .container-padding {
   padding: 0 16px !important;
 }
+
+/* Fix padding container in bottom sheets */
+.bottom-sheet-container {
+  padding: 36px 24px !important;
+}


### PR DESCRIPTION
En #120 se quitó el padding de todos los containers.
Esto afectó a los bottom-sheet (AddPlayerSheet y EditPlayerSheet) de PlayersView que tenían padding específico.
Agregado fix para que mantengan su estilo.

Closes #122 