### PR TITLE
style: Unificar estilos de botones en los componentes existentes

### DIFF
--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -29,7 +29,7 @@ const emit = defineEmits<{
     <v-card-actions>
       <v-btn
         color="primary"
-        variant="plain"
+        variant="flat"
         @click="emit('add-game', boardgame)"
       >
         <FontAwesomeIcon :icon="faPlus" />

--- a/src/components/molecules/PlayerCard.vue
+++ b/src/components/molecules/PlayerCard.vue
@@ -41,7 +41,7 @@ const handleDeletePlayer = () => {
         @click="handleEditPlayer"  
         class="action-btn button-edit"
         color="primary"
-        variant="plain"
+        variant="flat"
       >
         <FontAwesomeIcon :icon="faPenToSquare" class="icon-edit" />
         <span>Editar</span>
@@ -51,7 +51,7 @@ const handleDeletePlayer = () => {
         @click="handleDeletePlayer"
         class="action-btn button-delete"
         color="error"
-        variant="plain" 
+        variant="text" 
       >
         <FontAwesomeIcon :icon="faTrash" class="icon-delete" />
         <span>Borrar</span>

--- a/src/components/organisms/AddPlayerSheet.vue
+++ b/src/components/organisms/AddPlayerSheet.vue
@@ -73,6 +73,7 @@ defineExpose({
             <v-btn 
               type="submit" 
               color="primary"
+              variant="elevated"
               @click="submitForm"
               data-testid="btn-add-player"
             >{{ AddPlayerSheetText.buttons.add }}</v-btn>

--- a/src/components/organisms/EditPlayerSheet.vue
+++ b/src/components/organisms/EditPlayerSheet.vue
@@ -100,6 +100,7 @@ defineExpose({
               type="submit" 
               color="primary"
               @click="submitForm"
+              variant="elevated"
               :disabled="!isNameChanged"
               data-testid="btn-add-player"
             >{{ EditPlayerSheetText.buttons.save }}</v-btn>

--- a/src/views/Players/PlayersView.vue
+++ b/src/views/Players/PlayersView.vue
@@ -154,6 +154,7 @@ const sortedPlayers = computed(()=> {
         <v-btn 
           @click="showAddPlayerSheet"
           color="primary"
+          variant="elevated"
         >
           Agregar jugador
         </v-btn>


### PR DESCRIPTION
En #130 corregí el problema que estaba causando que los estilos de Vuetify se comportaran de manera errática. En vite.config.js, el mock de los estilos de Vuetify se estaba aplicando globalmente en vez de solo en los tests. Esto generaba los issues con los botones, el select y que no funcionaran las clases de utilidades. 

Objetivo:
- Unificar el uso de las variantes de botones en los componentes existentes

Closes #126 