### PR TITLE
Fix: Corregir tests con error en manejo de peticiones Internal Server Error

### DIFF
--- a/src/api/collectionApiService.spec.ts
+++ b/src/api/collectionApiService.spec.ts
@@ -25,7 +25,10 @@ describe("collectionApiService: getCollections()", ()=> {
   });
 
   it("error: internal server error (500)", async()=> {
-    vi.spyOn(global, "fetch").mockRejectedValue(new TypeError(API_ERROR_MESSAGES.GET_COLLECTIONS_FAILED(500)));
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 500
+    } as unknown as Response);
 
     await expect(getCollections()).rejects.toThrow(API_ERROR_MESSAGES.GET_COLLECTIONS_FAILED(500));
   });


### PR DESCRIPTION
Hay tests que están usando mockRejectValue para hacer el test de las peticiones de error que devuelven un 500 (internal server error).
Estas peticiones deben devolver un resolve con ok: false y status: 500.

Archivos a corregir:
- collectionApiService.spec.ts

Corrección:
En los tests de composables, para el caso de un status: 500 de internal server error, los composables lanzan un error. Por lo que sería equivocado cambiar estas función.
Los tests sobre los servicios que llaman directamente a la API usan mockResolvedValueOnce en caso de internal server error. Para los composables es correcto que se mockee un reject value.

Closes #144 