### PR TITLE
Fix: BottomNavButton no muestra el label del botón

### DIFF
--- a/src/components/atoms/typography/BottomNavLabel.vue
+++ b/src/components/atoms/typography/BottomNavLabel.vue
@@ -22,7 +22,7 @@ defineOptions({ name: "BottomNavLabel" });
 
 @media(max-width: 350px) {
   .bottom-nav-label {
-    display: none !important;
+    font-size: var(--font-size-2xs);
   }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -54,6 +54,7 @@
   --font-title: "Ruda", sans-serif;
   --font-text: "Lato", sans-serif;
 
+  --font-size-2xs: clamp(0.5rem, 0.7vw, 10px);
   --font-size-xxs: clamp(0.7rem, 0.8vw, 12px);
   --font-size-xs:  clamp(0.8rem, 0.9vw, 14px);
   --font-size-sm:  clamp(0.9rem, 1vw, 16px);


### PR DESCRIPTION
### Issue
En BottomNavigation, se ve el icono de cada BottomNavButton pero no se ve el texto correspondiente. El texto estaba presente para mejorar accesibilidad.

### Solución
El label estaba oculto debajo de 350px, agregado font-size 2xs para poder mostrar el label en los viewports más pequeños.

Closes #165 