### PR TITLE
Refactor: Agregar 4 cols a CardGrid en XL

### DIFF
--- a/src/api/gameApiService.ts
+++ b/src/api/gameApiService.ts
@@ -28,7 +28,7 @@ export async function createGame(newGame: CreateGameRequest) {
 
 }
 
-export async function getGames(limit: number = 10, offset: number = 0) {
+export async function getGames(limit: number = 12, offset: number = 0) {
   try {
     const response = await fetch(`${API_BASE_URL}v1/games?limit=${limit}&offset=${offset}&include=players`, { method: "GET" });
 

--- a/src/components/organisms/CardGrid.vue
+++ b/src/components/organisms/CardGrid.vue
@@ -53,6 +53,7 @@ onBeforeMount(()=> {
         cols="12"
         sm="6"
         lg="4"
+        xl="3"
       >
         <PlayerCard v-if="isPlayer(item)" 
           :player="item"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -29,6 +29,11 @@ export const routes = [
     component: () => import(/*webpackChunkName: "AddGame" */ "@/views/Games/AddGame.vue"),
     props: true,
   },
+  {
+    path: "/tipografia",
+    name: "Typography",
+    component: () => import(/*webpackChunkName: "Tipografia" */"@/views/Typography.vue"),
+  }
 ];
 
 const router = createRouter({

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useGamesApi } from "../../composables/useGamesApi";
 import { onBeforeMount } from "vue";
-import TypographyChart from "../../components/molecules/TypographyChart.vue";
 import DisplayTitle from "../../components/atoms/typography/DisplayTitle.vue";
 import CardGrid from "../../components/organisms/CardGrid.vue";
 import LoadingRow from "../../components/molecules/LoadingRow.vue";
@@ -41,7 +40,7 @@ onBeforeMount(async () => {
       type="game"
     ></CardGrid>
 
-    <TypographyChart></TypographyChart>
+
   </v-container>
 </template>
 

--- a/src/views/Typography.vue
+++ b/src/views/Typography.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import TypographyChart from '../components/molecules/TypographyChart.vue';
+
+</script>
+
+
+<template>
+  <v-container>
+    <TypographyChart></TypographyChart>
+  </v-container>
+</template>


### PR DESCRIPTION
En XL. tener solo 3 cards por fila hacía que las cards se estiraran demasiado. Pasar a tener 4 cards por row en XL mejoraría el diseño.

## Cambios realizados:
- Actualización de CardGrid para que muestre 4 cards en XL
- Actualizada el parámetro de cards que muestra getGames de 10 a 12 cards. De esa manera, el diseño se mantiene estable sin cards huérfanas
- Creada vista para Typography con el componente TypographyChart. Agregada al router, si link visible en la app

Closes #182 