### PR TITLE
Refactor: actualizar rutas de importación para que usen alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,8 @@ npm run test:coverage # Coverage de tests
 - Dockerfile: Producción (multi-stage)
 - Dockerfile.dev: Desarrollo con hot-reload
 - Puerto de desarrollo: 3000
+
+## Desarrollo
+
+- Se usa el alias @ para las rutas de componentes
+- Se mantiene el uso de rutas relativas para types usados en defineProps(), sino genera un error

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,11 @@
     "target": "es2020", 
     "module": "esnext",
     "moduleResolution": "node",
-    "allowJs": true
+    "allowJs": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   // le dice a VS code que mire en src
   "include": ["src/**/*", "env.d.ts"] 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import BottomNavigation from "./components/organisms/BottomNavigation.vue";
-import NavBar from "./components/organisms/NavBar.vue";
+import BottomNavigation from "@/components/organisms/BottomNavigation.vue";
+import NavBar from "@/components/organisms/NavBar.vue";
 import { useWindowSize } from "@vueuse/core";
-import AppSnackbar from "./components/molecules/AppSnackbar.vue";
+import AppSnackbar from "@/components/molecules/AppSnackbar.vue";
 import { onMounted, ref, type Ref, watch } from "vue";
-import { useServerTime } from "./composables/useServerTime";
-import { useCheckDbHealth } from "./composables/useCheckDbHealth";
-import { useAppSnackbar } from "./composables/useAppSnackbar";
+import { useServerTime } from "@/composables/useServerTime";
+import { useCheckDbHealth } from "@/composables/useCheckDbHealth";
+import { useAppSnackbar } from "@/composables/useAppSnackbar";
 
 defineOptions({ name: "App" });
 

--- a/src/api/collectionApiService.spec.ts
+++ b/src/api/collectionApiService.spec.ts
@@ -1,7 +1,7 @@
 import { it, vi, describe, expect, afterEach } from "vitest";
-import { mockCollectionsListResponse } from "../mocks/data/collectionsApi";
+import { mockCollectionsListResponse } from "@/mocks/data/collectionsApi";
 import { getCollections } from "./collectionApiService";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/api/collectionApiService.ts
+++ b/src/api/collectionApiService.ts
@@ -1,5 +1,5 @@
-import type { CollectionsApiResponse, CollectionsListResponse } from "../types/domain/collectionsApi";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import type { CollectionsApiResponse, CollectionsListResponse } from "@/types/domain/collectionsApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/api/gameApiService.ts
+++ b/src/api/gameApiService.ts
@@ -1,5 +1,5 @@
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import type { GameApiResponse, GamesListResponse, PlayerInGame, CreateGameRequest } from "../types/domain/gamesApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import type { GameApiResponse, GamesListResponse, PlayerInGame, CreateGameRequest } from "@/types/domain/gamesApi";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/api/playerApiService.spec.ts
+++ b/src/api/playerApiService.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { getPlayers, getPlayer, deletePlayer, createPlayer, updatePlayer } from "./playerApiService";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import type { PlayersListResponse, PlayerApiResponse, CreatePlayerRequest, UpdatePlayerRequest } from "../types/domain/playerApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import type { PlayersListResponse, PlayerApiResponse, CreatePlayerRequest, UpdatePlayerRequest } from "@/types/domain/playerApi";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/api/playerApiService.ts
+++ b/src/api/playerApiService.ts
@@ -1,5 +1,5 @@
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import type { PlayerApiResponse, PlayersListResponse, CreatePlayerRequest, UpdatePlayerRequest } from "../types/domain/playerApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import type { PlayerApiResponse, PlayersListResponse, CreatePlayerRequest, UpdatePlayerRequest } from "@/types/domain/playerApi";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/components/atoms/Logo.spec.ts
+++ b/src/components/atoms/Logo.spec.ts
@@ -1,10 +1,10 @@
 import { it, expect, describe, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import Logo from "./Logo.vue";
-import { router } from "../../tests/utils/createRouterMock";
-import { routerLinkStub } from "../../tests/utils/stubRouterLink";
+import { router } from "@/tests/utils/createRouterMock";
+import { routerLinkStub } from "@/tests/utils/stubRouterLink";
 import { VChip } from "vuetify/components";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import version from "./../../../VERSION?raw";
 
 const vuetify = createVuetifyForTest({ VChip });

--- a/src/components/atoms/Logo.vue
+++ b/src/components/atoms/Logo.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import version from "./../../../VERSION?raw";
-import BottomNavLabel from "./typography/BottomNavLabel.vue";
+import BottomNavLabel from "@/components/atoms/typography/BottomNavLabel.vue";
 defineOptions({ name: "Logo" });
 
 </script>

--- a/src/components/atoms/buttons/AppButton.vue
+++ b/src/components/atoms/buttons/AppButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import ButtonLabel from '../typography/ButtonLabel.vue';
+import ButtonLabel from '@/components/atoms/typography/ButtonLabel.vue';
 
 interface Props {
   color?: string,

--- a/src/components/atoms/buttons/BottomNavButton.spec.ts
+++ b/src/components/atoms/buttons/BottomNavButton.spec.ts
@@ -1,11 +1,11 @@
 import { it, expect, beforeEach, describe } from "vitest";
 import { mount } from "@vue/test-utils";
-import { createVuetifyForTest } from "../../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import { faVial } from "@fortawesome/free-solid-svg-icons";
-import { NavButton } from "../../../types/navigation";
+import { NavButton } from "@/types/navigation";
 import BottomNavButton from "./BottomNavButton.vue";
 import { VBtn } from "vuetify/components";
-import { router } from "../../../tests/utils/createRouterMock";
+import { router } from "@/tests/utils/createRouterMock";
 
 const vuetify = createVuetifyForTest({ VBtn });
 const faVialText = faVial.iconName;

--- a/src/components/atoms/buttons/BottomNavButton.vue
+++ b/src/components/atoms/buttons/BottomNavButton.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { NavButton } from "../../../types/navigation";
-import BottomNavLabel from "../typography/BottomNavLabel.vue";
+import { NavButton } from "@/types/navigation";
+import BottomNavLabel from "@/components/atoms/typography/BottomNavLabel.vue";
 import { useRoute } from "vue-router";
 
 const props = defineProps<NavButton>();

--- a/src/components/atoms/buttons/BottomNavButton.vue
+++ b/src/components/atoms/buttons/BottomNavButton.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { NavButton } from "@/types/navigation";
+import { NavButton } from "../../../types/navigation";
 import BottomNavLabel from "@/components/atoms/typography/BottomNavLabel.vue";
 import { useRoute } from "vue-router";
 

--- a/src/components/atoms/typography/NavigationLink.spec.ts
+++ b/src/components/atoms/typography/NavigationLink.spec.ts
@@ -1,8 +1,8 @@
 import { it, expect, describe, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import NavigationLink from "./NavigationLink.vue";
-import { router } from "../../../tests/utils/createRouterMock";
-import { routerLinkStub } from "../../../tests/utils/stubRouterLink";
+import { router } from "@/tests/utils/createRouterMock";
+import { routerLinkStub } from "@/tests/utils/stubRouterLink";
 
 const classNavLink = "navigation-link";
 

--- a/src/components/molecules/AppSnackbar.spec.ts
+++ b/src/components/molecules/AppSnackbar.spec.ts
@@ -18,7 +18,7 @@ globalThis.visualViewport = {
 
 import { mount } from "@vue/test-utils";
 import AppSnackbar from "./AppSnackbar.vue";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import { VSnackbar } from "vuetify/components";
 import { nextTick } from "vue";
 import { afterEach } from "node:test";

--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -2,8 +2,8 @@
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
-import CardHeading from '../atoms/typography/CardHeading.vue';
-import AppButton from '../atoms/buttons/AppButton.vue';
+import CardHeading from '@/components/atoms/typography/CardHeading.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
 
 const props = defineProps<{
   boardgame: CollectionsApiResponse

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -3,13 +3,12 @@ import type { GameApiResponse } from '../../types/domain/gamesApi';
 import { ref } from "vue";
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faTrophy, faChevronDown, faChevronUp, } from '@fortawesome/free-solid-svg-icons';
-import CardHeading from '../atoms/typography/CardHeading.vue';
-import MinorHeading from '../atoms/typography/MinorHeading.vue';
-import BodyText from '../atoms/typography/BodyText.vue';
-import EditButton from '../atoms/buttons/EditButton.vue';
-import DeleteButton from '../atoms/buttons/DeleteButton.vue';
-import DetailText from '../atoms/typography/DetailText.vue';
-import { formatDate } from '../../utils/formatters';
+import CardHeading from '@/components/atoms/typography/CardHeading.vue';
+import MinorHeading from '@/components/atoms/typography/MinorHeading.vue';
+import EditButton from '@/components/atoms/buttons/EditButton.vue';
+import DeleteButton from '@/components/atoms/buttons/DeleteButton.vue';
+import DetailText from '@/components/atoms/typography/DetailText.vue';
+import { formatDate } from '@/utils/formatters';
 
 defineOptions({ name: "GameCard" });
 

--- a/src/components/molecules/PlayerCard.spec.ts
+++ b/src/components/molecules/PlayerCard.spec.ts
@@ -1,12 +1,12 @@
 import { it, describe, beforeEach, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import PlayerCard from "./PlayerCard.vue";
-import { mockSinglePlayer, mockRegisteredSinglePlayer } from "../../mocks/data/playersApi";
+import { mockSinglePlayer, mockRegisteredSinglePlayer } from "@/mocks/data/playersApi";
 import { VCard, VCardActions, VCardText, VBtn, VCardItem, VAvatar } from "vuetify/components";
 import { faTrash, faPenToSquare, faCircleCheck } from "@fortawesome/free-solid-svg-icons";
 import { nextTick } from "vue";
-import { findInitials } from "../../utils/generalUtils";
+import { findInitials } from "@/utils/generalUtils";
 
 const vuetify = createVuetifyForTest({ VCard, VCardActions, VCardText, VBtn, VCardItem, VAvatar });
 const faTrashText = faTrash.iconName;

--- a/src/components/molecules/PlayerCard.vue
+++ b/src/components/molecules/PlayerCard.vue
@@ -2,12 +2,12 @@
 import type { PlayerApiResponse } from '../../types/domain/playerApi';
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faTrash, faPenToSquare, faCircleCheck } from "@fortawesome/free-solid-svg-icons";
-import { findInitials, getRandomNumber } from '../../utils/generalUtils';
+import { findInitials, getRandomNumber } from '@/utils/generalUtils';
 import { ref, type Ref } from "vue";
-import AppButton from '../atoms/buttons/AppButton.vue';
-import MinorHeading from '../atoms/typography/MinorHeading.vue';
-import EditButton from '../atoms/buttons/EditButton.vue';
-import DeleteButton from '../atoms/buttons/DeleteButton.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
+import MinorHeading from '@/components/atoms/typography/MinorHeading.vue';
+import EditButton from '@/components/atoms/buttons/EditButton.vue';
+import DeleteButton from '@/components/atoms/buttons/DeleteButton.vue';
 
 const props = defineProps<{
   player: PlayerApiResponse,

--- a/src/components/molecules/ThemeToggler.spec.ts
+++ b/src/components/molecules/ThemeToggler.spec.ts
@@ -1,9 +1,9 @@
 import { it, describe, expect, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import ThemeToggler from "./ThemeToggler.vue";
-import { VBtn, VTooltip } from "vuetify/components";
+import { VBtn, VTooltip} from "vuetify/components";
 import { faSun, faMoon } from "@fortawesome/free-solid-svg-icons";
 import { consoleError } from "vuetify/lib/util";
 

--- a/src/components/molecules/TypographyChart.vue
+++ b/src/components/molecules/TypographyChart.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import DisplayTitle from '../atoms/typography/DisplayTitle.vue';
-import SectionTitle from '../atoms/typography/SectionTitle.vue';
-import SubsectionTitle from '../atoms/typography/SubsectionTitle.vue';
-import BlockHeading from '../atoms/typography/BlockHeading.vue';
-import CardHeading from '../atoms/typography/CardHeading.vue';
-import MinorHeading from '../atoms/typography/MinorHeading.vue';
-import LeadText from '../atoms/typography/LeadText.vue';
-import SupportText from '../atoms/typography/SupportText.vue';
-import BodyText from '../atoms/typography/BodyText.vue';
-import DetailText from '../atoms/typography/DetailText.vue';
-import CaptionText from '../atoms/typography/CaptionText.vue';
-import ButtonLabel from '../atoms/typography/ButtonLabel.vue';
-import NavigationLink from '../atoms/typography/NavigationLink.vue';
-import ExternalLink from '../atoms/typography/ExternalLink.vue';
+import DisplayTitle from '@/components/atoms/typography/DisplayTitle.vue';
+import SectionTitle from '@/components/atoms/typography/SectionTitle.vue';
+import SubsectionTitle from '@/components/atoms/typography/SubsectionTitle.vue';
+import BlockHeading from '@/components/atoms/typography/BlockHeading.vue';
+import CardHeading from '@/components/atoms/typography/CardHeading.vue';
+import MinorHeading from '@/components/atoms/typography/MinorHeading.vue';
+import LeadText from '@/components/atoms/typography/LeadText.vue';
+import SupportText from '@/components/atoms/typography/SupportText.vue';
+import BodyText from '@/components/atoms/typography/BodyText.vue';
+import DetailText from '@/components/atoms/typography/DetailText.vue';
+import CaptionText from '@/components/atoms/typography/CaptionText.vue';
+import ButtonLabel from '@/components/atoms/typography/ButtonLabel.vue';
+import NavigationLink from '@/components/atoms/typography/NavigationLink.vue';
+import ExternalLink from '@/components/atoms/typography/ExternalLink.vue';
 
 </script>
 

--- a/src/components/organisms/AddGameDialog.vue
+++ b/src/components/organisms/AddGameDialog.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
-import { AddGameDialogText } from '../../constants/ui_text/AddGameDialog';
+import { AddGameDialogText } from '@/constants/ui_text/AddGameDialog';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
-import { usePlayersApi } from '../../composables/usePlayersApi';
-import { useGamesApi } from '../../composables/useGamesApi'; 
+import { usePlayersApi } from '@/composables/usePlayersApi';
+import { useGamesApi } from '@/composables/useGamesApi'; 
 import { onBeforeMount, ref, type Ref, watch } from 'vue';
-import LoadingRow from '../molecules/LoadingRow.vue';
+import LoadingRow from '@/components/molecules/LoadingRow.vue';
 import { PlayerApiResponse } from '../../types/domain/playerApi';
 import { object, string, date, array, boolean } from "yup";
 import { toTypedSchema } from "@vee-validate/yup";
 import { useField, useForm, useFieldArray } from "vee-validate";
 import type { PlayerInGame, CreateGameRequest } from '../../types/domain/gamesApi';
-import BlockHeading from '../atoms/typography/BlockHeading.vue';
-import DetailText from '../atoms/typography/DetailText.vue';
-import AppButton from '../atoms/buttons/AppButton.vue';
+import BlockHeading from '@/components/atoms/typography/BlockHeading.vue';
+import DetailText from '@/components/atoms/typography/DetailText.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
 
 const props =  defineProps<{
   modelValue: boolean,

--- a/src/components/organisms/AddPlayerSheet.spec.ts
+++ b/src/components/organisms/AddPlayerSheet.spec.ts
@@ -1,11 +1,11 @@
 import { it, describe, expect, beforeEach } from "vitest";
 import { createWrapperError, mount } from "@vue/test-utils";
-import { setTextInputValue } from "../../tests/utils/form-helpers";
+import { setTextInputValue } from "@/tests/utils/form-helpers";
 import { nextTick } from "vue";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import { VBottomSheet, VContainer, VTextField, VBtn, VSheet, VAlert } from "vuetify/components";
 import AddPlayerSheet from "./AddPlayerSheet.vue";
-import { AddPlayerSheetText } from "../../constants/ui_text/AddPlayerSheet";
+import { AddPlayerSheetText } from "@/constants/ui_text/AddPlayerSheet";
  
 const vuetify = createVuetifyForTest({ VBottomSheet, VContainer, VTextField, VBtn, VSheet, VAlert });
  

--- a/src/components/organisms/AddPlayerSheet.vue
+++ b/src/components/organisms/AddPlayerSheet.vue
@@ -1,12 +1,12 @@
 <script lang="ts" setup>
-import SubsectionTitle from '../atoms/typography/SubsectionTitle.vue';
-import AppButton from '../atoms/buttons/AppButton.vue';
+import SubsectionTitle from '@/components/atoms/typography/SubsectionTitle.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
 import { object, string } from "yup";
 import { toTypedSchema } from '@vee-validate/yup';
 import { useForm, useField } from 'vee-validate';
 import { computed } from "vue";
 import { VExpandTransition } from 'vuetify/components';
-import { AddPlayerSheetText } from '../../constants/ui_text/AddPlayerSheet';
+import { AddPlayerSheetText } from '@/constants/ui_text/AddPlayerSheet';
 
 defineProps<{
   modelValue: boolean,

--- a/src/components/organisms/BottomNavigation.vue
+++ b/src/components/organisms/BottomNavigation.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { faDice, faUsers, faBoxArchive } from "@fortawesome/free-solid-svg-icons";
 import { NavButton } from "../../types/navigation";
-import BottomNavButton from "../atoms/buttons/BottomNavButton.vue";
-import ThemeToggler from "../molecules/ThemeToggler.vue";
+import BottomNavButton from '@/components/atoms/buttons/BottomNavButton.vue';
+import ThemeToggler from '@/components/molecules/ThemeToggler.vue';
 
 defineOptions({ name: "BottomNavigation" });
 

--- a/src/components/organisms/CardGrid.vue
+++ b/src/components/organisms/CardGrid.vue
@@ -3,9 +3,9 @@ import type { PlayerApiResponse } from '../../types/domain/playerApi';
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
 import { GameApiResponse } from '../../types/domain/gamesApi';
 import { onBeforeMount } from 'vue';
-import PlayerCard from '../molecules/PlayerCard.vue';
-import BoardgameCard from '../molecules/BoardgameCard.vue';
-import GameCard from '../molecules/GameCard.vue';
+import PlayerCard from '@/components/molecules/PlayerCard.vue';
+import BoardgameCard from '@/components/molecules/BoardgameCard.vue';
+import GameCard from '@/components/molecules/GameCard.vue';
 
 type GridItem = PlayerApiResponse | CollectionsApiResponse | GameApiResponse;
 

--- a/src/components/organisms/EditPlayerSheet.vue
+++ b/src/components/organisms/EditPlayerSheet.vue
@@ -1,12 +1,12 @@
 <script lang="ts" setup>
-import SubsectionTitle from '../atoms/typography/SubsectionTitle.vue';
-import AppButton from '../atoms/buttons/AppButton.vue';
+import SubsectionTitle from '@/components/atoms/typography/SubsectionTitle.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
 import { object, string } from "yup";
 import { toTypedSchema } from '@vee-validate/yup';
 import { useForm, useField } from 'vee-validate';
 import { ref, computed, watch } from "vue";
 import { VExpandTransition } from 'vuetify/components';
-import { EditPlayerSheetText } from '../../constants/ui_text/EditPlayerSheet';
+import { EditPlayerSheetText } from '@/constants/ui_text/EditPlayerSheet';
 import { PlayerApiResponse, UpdatePlayerRequest } from "../../types/domain/playerApi"
 
 const props = defineProps<{

--- a/src/components/organisms/NavBar.spec.ts
+++ b/src/components/organisms/NavBar.spec.ts
@@ -1,11 +1,11 @@
 import { it, describe, beforeEach, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
-import { router } from "../../tests/utils/createRouterMock";
+import { router } from "@/tests/utils/createRouterMock";
 import { nextTick } from "vue";
-import { createVuetifyForTest } from "../../tests/utils/createVuetifyForTest";
-import { mockViewportForVueUse } from "../../tests/utils/mockViewportForVueUse";
-import { expectNavigationLinks } from "../../tests/utils/expectNavigationLinks";
-import { NavigationLinkStub } from "../../tests/utils/stubNavigationLink";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
+import { mockViewportForVueUse } from "@/tests/utils/mockViewportForVueUse";
+import { expectNavigationLinks } from "@/tests/utils/expectNavigationLinks";
+import { NavigationLinkStub } from "@/tests/utils/stubNavigationLink";
 import { VAppBar, VNavigationDrawer, VBtn, VRow, VContainer, VList, VTooltip, VChip } from "vuetify/components";
 import NavBar from "./NavBar.vue";
 import { faBars } from "@fortawesome/free-solid-svg-icons";

--- a/src/components/organisms/NavBar.vue
+++ b/src/components/organisms/NavBar.vue
@@ -3,9 +3,9 @@ import { ref } from 'vue';
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { useBreakpoints } from '@vueuse/core';
-import NavigationLink from '../atoms/typography/NavigationLink.vue';
-import ThemeToggler from '../molecules/ThemeToggler.vue';
-import Logo from '../atoms/Logo.vue';
+import NavigationLink from '@/components/atoms/typography/NavigationLink.vue';
+import ThemeToggler from '@/components/molecules/ThemeToggler.vue';
+import Logo from '@/components/atoms/Logo.vue';
 
 const drawer = ref(false);
 const breakpoints = useBreakpoints({

--- a/src/composables/useAppSnackbar.spec.ts
+++ b/src/composables/useAppSnackbar.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { useAppSnackbar } from "./useAppSnackbar";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import { StatusColors, SnackbarDisplayTimes } from "../types/general";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import { StatusColors, SnackbarDisplayTimes } from "@/types/general";
 
 const expectInitialValues = (isSnackbarVisible: boolean, message: string, color: string, timeout: number) => {
   expect(isSnackbarVisible).toBe(false);

--- a/src/composables/useAppSnackbar.ts
+++ b/src/composables/useAppSnackbar.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from "vue";
-import { StatusColors, SnackbarDisplayTimes } from "../types/general";
+import { StatusColors, SnackbarDisplayTimes } from "@/types/general";
  
 export function useAppSnackbar() {
   const isSnackbarVisible: Ref<boolean> = ref(false);

--- a/src/composables/useCheckDbHealth.spec.ts
+++ b/src/composables/useCheckDbHealth.spec.ts
@@ -1,7 +1,7 @@
 import { it, describe, afterEach, vi, expect } from "vitest";
 import { useCheckDbHealth } from "./useCheckDbHealth";
 import { useServerTime } from "./useServerTime";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 
 describe("checkHealth()", () => {
   // Arrange

--- a/src/composables/useCheckDbHealth.ts
+++ b/src/composables/useCheckDbHealth.ts
@@ -1,6 +1,6 @@
 import { ref, type Ref } from "vue";
 import { useServerTime } from "./useServerTime";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 
 export function useCheckDbHealth() {
   const BASE_URL = import.meta.env.VITE_API_HEALTH_BASE_URL;

--- a/src/composables/useCollectionsApi.spec.ts
+++ b/src/composables/useCollectionsApi.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, afterEach, vi, expect } from "vitest";
-import * as CollectionApiService from "../api/collectionApiService";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import { mockCollectionsListResponse, mockCollectionsEmptyListResponse } from "../mocks/data/collectionsApi";
+import * as CollectionApiService from "@/api/collectionApiService";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import { mockCollectionsListResponse, mockCollectionsEmptyListResponse } from "@/mocks/data/collectionsApi";
 import { useCollectionsApi } from "./useCollectionsApi";
-import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "../tests/utils/apiComposables";
+import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "@/tests/utils/apiComposables";
 
 describe("fetchCollections", ()=> {
   afterEach(()=> {

--- a/src/composables/useCollectionsApi.ts
+++ b/src/composables/useCollectionsApi.ts
@@ -1,6 +1,6 @@
-import * as CollectionApiService from "../api/collectionApiService";
+import * as CollectionApiService from "@/api/collectionApiService";
 import { ref, type Ref } from "vue";
-import { CollectionsApiResponse, CollectionsListResponse } from "../types/domain/collectionsApi";
+import { CollectionsApiResponse, CollectionsListResponse } from "@/types/domain/collectionsApi";
 
 export function useCollectionsApi() {
   const collection: Ref<CollectionsApiResponse[]> = ref([]);

--- a/src/composables/useGamesApi.ts
+++ b/src/composables/useGamesApi.ts
@@ -1,6 +1,6 @@
-import * as GamesApiService from "../api/gameApiService";
+import * as GamesApiService from "@/api/gameApiService";
 import { ref, type Ref } from "vue";
-import { CreateGameRequest, GameApiResponse, GamesListResponse } from "../types/domain/gamesApi";
+import { CreateGameRequest, GameApiResponse, GamesListResponse } from "@/types/domain/gamesApi";
 
 export function useGamesApi() {
   const loading: Ref<boolean> = ref(false);

--- a/src/composables/usePlayerApi.spec.ts
+++ b/src/composables/usePlayerApi.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import * as PlayerApiService from "../api/playerApiService";
-import { mockSinglePlayer } from "../mocks/data/playersApi";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import * as PlayerApiService from "@/api/playerApiService";
+import { mockSinglePlayer } from "@/mocks/data/playersApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 import { usePlayerApi } from "./usePlayerApi";
-import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "../tests/utils/apiComposables";
+import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "@/tests/utils/apiComposables";
 import { updateRelative } from "vuetify/lib/labs/VCalendar/util/timestamp";
 
 describe("usePlayerApi", ()=> {

--- a/src/composables/usePlayerApi.ts
+++ b/src/composables/usePlayerApi.ts
@@ -1,6 +1,6 @@
-import * as PlayerApiService from "../api/playerApiService";
+import * as PlayerApiService from "@/api/playerApiService";
 import { ref, type Ref } from "vue";
-import type { PlayerApiResponse, CreatePlayerRequest, UpdatePlayerRequest } from "../types/domain/playerApi";
+import type { PlayerApiResponse, CreatePlayerRequest, UpdatePlayerRequest } from "@/types/domain/playerApi";
 
 export function usePlayerApi() {
   const player: Ref<PlayerApiResponse | null> = ref(null);

--- a/src/composables/usePlayersApi.spec.ts
+++ b/src/composables/usePlayersApi.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import * as PlayerApiService from "../api/playerApiService";
-import { mockPlayersApi, mockPlayersListResponse } from "../mocks/data/playersApi";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import * as PlayerApiService from "@/api/playerApiService";
+import { mockPlayersApi, mockPlayersListResponse } from "@/mocks/data/playersApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 import { usePlayersApi } from "./usePlayersApi";
-import { CreatePlayerRequest, PlayerApiResponse } from "../types/domain/playerApi";
-import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "../tests/utils/apiComposables";
+import { CreatePlayerRequest, PlayerApiResponse } from "@/types/domain/playerApi";
+import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "@/tests/utils/apiComposables";
 
 describe("usePlayersApi", ()=> {
   afterEach(()=> {

--- a/src/composables/usePlayersApi.ts
+++ b/src/composables/usePlayersApi.ts
@@ -1,6 +1,6 @@
-import * as PlayerApiService from "../api/playerApiService";
+import * as PlayerApiService from "@/api/playerApiService";
 import { ref, type Ref } from "vue";
-import type { PlayerApiResponse, PlayersListResponse, CreatePlayerRequest } from "../types/domain/playerApi";
+import type { PlayerApiResponse, PlayersListResponse, CreatePlayerRequest } from "@/types/domain/playerApi";
 
 export function usePlayersApi() {
   const players: Ref<PlayerApiResponse[]> = ref([]);

--- a/src/tests/utils/createRouterMock.ts
+++ b/src/tests/utils/createRouterMock.ts
@@ -5,7 +5,7 @@ import {
 } from 'vue-router-mock';
 import { config } from '@vue/test-utils';
 import { beforeEach, vi } from "vitest";
-import { routes as actualRoutes } from "../../router/index.js";
+import { routes as actualRoutes } from "@/router/index.js";
 
 // create one router per test file
 const router = createRouterMock({

--- a/src/views/BoardGames/BoardGamesView.vue
+++ b/src/views/BoardGames/BoardGamesView.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { onBeforeMount, ref, type Ref } from "vue";
-import { useCollectionsApi } from '../../composables/useCollectionsApi';
-import CardGrid from '../../components/organisms/CardGrid.vue';
-import LoadingRow from '../../components/molecules/LoadingRow.vue';
-import AddGameDialog from '../../components/organisms/AddGameDialog.vue';
+import { useCollectionsApi } from '@/composables/useCollectionsApi';
+import CardGrid from '@/components/organisms/CardGrid.vue';
+import LoadingRow from '@/components/molecules/LoadingRow.vue';
+import AddGameDialog from '@/components/organisms/AddGameDialog.vue';
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
-import AppSnackbar from "../../components/molecules/AppSnackbar.vue";
-import { useAppSnackbar } from "../../composables/useAppSnackbar";
-import DisplayTitle from "../../components/atoms/typography/DisplayTitle.vue";
-import { GENERAL_UI_TEXT } from "../../constants/generalText";
+import AppSnackbar from "@/components/molecules/AppSnackbar.vue";
+import { useAppSnackbar } from "@/composables/useAppSnackbar";
+import DisplayTitle from "@/components/atoms/typography/DisplayTitle.vue";
+import { GENERAL_UI_TEXT } from "@/constants/generalText";
 
 defineOptions({ name: "BoardGamesView" });
 

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { useGamesApi } from "../../composables/useGamesApi";
+import { useGamesApi } from "@/composables/useGamesApi";
 import { onBeforeMount } from "vue";
-import DisplayTitle from "../../components/atoms/typography/DisplayTitle.vue";
-import CardGrid from "../../components/organisms/CardGrid.vue";
-import LoadingRow from "../../components/molecules/LoadingRow.vue";
-import { GENERAL_UI_TEXT } from "../../constants/generalText";
+import DisplayTitle from "@/components/atoms/typography/DisplayTitle.vue";
+import CardGrid from "@/components/organisms/CardGrid.vue";
+import LoadingRow from "@/components/molecules/LoadingRow.vue";
+import { GENERAL_UI_TEXT } from "@/constants/generalText";
 
 defineOptions({ name: "GamesView" });
 

--- a/src/views/Players/PlayersView.vue
+++ b/src/views/Players/PlayersView.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
 import { ref, type Ref, onBeforeMount, computed } from "vue";
-import AddPlayerSheet from "../../components/organisms/AddPlayerSheet.vue";
-import EditPlayerSheet from "../../components/organisms/EditPlayerSheet.vue";
-import { usePlayersApi } from "../../composables/usePlayersApi";
-import { usePlayerApi } from "../../composables/usePlayerApi";
-import CardGrid from "../../components/organisms/CardGrid.vue";
+import AddPlayerSheet from "@/components/organisms/AddPlayerSheet.vue";
+import EditPlayerSheet from "@/components/organisms/EditPlayerSheet.vue";
+import { usePlayersApi } from "@/composables/usePlayersApi";
+import { usePlayerApi } from "@/composables/usePlayerApi";
+import CardGrid from "@/components/organisms/CardGrid.vue";
 import type { CreatePlayerRequest, PlayerApiResponse, UpdatePlayerRequest } from "../../types/domain/playerApi";
-import { PLAYER_STATUS, CONFIRM_DELETE_PLAYER } from "../../constants/ui_feedback/players";
-import { GENERAL_UI_TEXT } from "../../constants/generalText";
-import { capitalize } from "../../utils/formatters";
-import LoadingRow from "../../components/molecules/LoadingRow.vue";
-import DisplayTitle from "../../components/atoms/typography/DisplayTitle.vue";
-import SubsectionTitle from "../../components/atoms/typography/SubsectionTitle.vue";
-import BodyText from "../../components/atoms/typography/BodyText.vue";
-import AppButton from "../../components/atoms/buttons/AppButton.vue";
-import { useAppSnackbar } from "../../composables/useAppSnackbar";
+import { PLAYER_STATUS, CONFIRM_DELETE_PLAYER } from "@/constants/ui_feedback/players";
+import { GENERAL_UI_TEXT } from "@/constants/generalText";
+import { capitalize } from "@/utils/formatters";
+import LoadingRow from "@/components/molecules/LoadingRow.vue";
+import DisplayTitle from "@/components/atoms/typography/DisplayTitle.vue";
+import SubsectionTitle from "@/components/atoms/typography/SubsectionTitle.vue";
+import BodyText from "@/components/atoms/typography/BodyText.vue";
+import AppButton from "@/components/atoms/buttons/AppButton.vue";
+import { useAppSnackbar } from "@/composables/useAppSnackbar";
 
 
 const isSheetVisible: Ref<boolean> = ref(false);

--- a/src/views/Typography.vue
+++ b/src/views/Typography.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import TypographyChart from '../components/molecules/TypographyChart.vue';
+import TypographyChart from '@/components/molecules/TypographyChart.vue';
 
 </script>
 


### PR DESCRIPTION
Actualmente, casi todos los componentes usan rutas relativas para importación de otros componentes. Esto hace más lento el tiempo de desarrollo. 

## Objetivo: 
- Configurar un alias para usar en las rutas
- Refactor de todos los componentes para que usen el alias en vez de rutas relativas

## Notas: 
- Se mantiene el uso de rutas relativas para types usados en defineProps(), sino genera un error

Closes #138 