### PR TITLE
Refactor: Eliminar MDI y migrar a FontAwesome 

### DIFF
--- a/src/components/atoms/buttons/AddButton.vue
+++ b/src/components/atoms/buttons/AddButton.vue
@@ -1,12 +1,6 @@
-<template>
-  <router-link :to="{ name: route }">
-    <v-btn class="btn-add" color="primary">
-      <v-icon icon="mdi:mdi-plus" /> <span>{{ text }}</span>
-    </v-btn>
-  </router-link>
-</template>
-
 <script setup>
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+
 const props = defineProps({
   text: {
     type: String,
@@ -20,6 +14,14 @@ const props = defineProps({
 
 defineOptions({ name: "AddGameButton" });
 </script>
+
+<template>
+  <router-link :to="{ name: route }">
+    <v-btn class="btn-add" color="primary">
+      <v-icon :icon="faPlus" /> <span>{{ text }}</span>
+    </v-btn>
+  </router-link>
+</template>
 
 <style scoped>
 .btn-add {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,15 +8,13 @@ import { createVuetify, useTheme } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import { aliases, fa } from "vuetify/iconsets/fa-svg";
-import { mdi } from "vuetify/iconsets/mdi";
-// FontAwesome, only icons to be used
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { 
-  faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare, 
-  faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck, 
-  faCheckSquare, faCalendar, faChevronLeft, faChevronRight, faChevronDown, 
-  faChevronUp, faFloppyDisk, faCircleCheck, faTrophy 
+import {
+  faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare,
+  faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck,
+  faCheckSquare, faCalendar, faChevronLeft, faChevronRight, faChevronDown,
+  faChevronUp, faFloppyDisk, faCircleCheck, faTrophy
 } from "@fortawesome/free-solid-svg-icons";
 import { VDateInput } from "vuetify/labs/VDateInput";
 
@@ -40,7 +38,7 @@ const COLOR = {
   ERROR_DARK: "#FF8A80",
   SUCCESS_DARK: "#81C784",
   INFO_DARK: "#64B5F6",
-  WARNING_DARK: "#FFD740", 
+  WARNING_DARK: "#FFD740",
 }
 
 // Theme definitions
@@ -145,9 +143,9 @@ async function prepareApp(): Promise<void> {
 
 // Font Awesome
 library.add(
-  faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare, 
-  faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck, faCheckSquare, 
-  faCalendar, faChevronLeft, faChevronRight, faChevronDown, faChevronUp, 
+  faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare,
+  faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck, faCheckSquare,
+  faCalendar, faChevronLeft, faChevronRight, faChevronDown, faChevronUp,
   faFloppyDisk, faCircleCheck, faTrophy
 );
 


### PR DESCRIPTION
MDI es la librería de iconos por default de Vuetify pero en el proyecto estoy usando FontAwesome. Tener dos librerías de iconos es redundante y aumenta el tamaño del bundle.

## Cambios realizados
- Eliminar MDI de la configuración
- Reemplazar icono de MDI por Fontawesome en componente AddButton.vue

Closes #23 