### PR TITLE
Feature: Agregar paginación a GamesView

### DIFF
--- a/src/api/gameApiService.ts
+++ b/src/api/gameApiService.ts
@@ -38,6 +38,7 @@ export async function getGames(limit: number = 12, offset: number = 0) {
     }
 
     const data: GamesListResponse = await response.json();
+    console.log(data)
     return data;
   } catch (err) {
     throw new Error(API_ERROR_MESSAGES.UNKNOWN_ERROR(err?.message));

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -9,6 +9,7 @@ import EditButton from '@/components/atoms/buttons/EditButton.vue';
 import DeleteButton from '@/components/atoms/buttons/DeleteButton.vue';
 import DetailText from '@/components/atoms/typography/DetailText.vue';
 import { formatDate } from '@/utils/formatters';
+import { GAME_CARD_TEXT } from '@/constants/ui_text/GameCard';
 
 defineOptions({ name: "GameCard" });
 
@@ -19,12 +20,12 @@ const props = defineProps<{
 const showDetails = ref(false);
 
 const countPlayers = () => {
-  return props.game.players.length;
+  return props.game.players.length ?? 0;
 }
 
 const getWinner = () => {
   const winner = props.game.players.find((player) => player.is_winner);
-  return winner.player_name;
+  return winner.player_name ?? "Desconocido";
 }
 
 </script>
@@ -47,9 +48,14 @@ const getWinner = () => {
       </DetailText>
     </v-card-subtitle>
 
-    <v-card-item class="game-card-players ps-2">
+    <v-card-item v-if="game.players?.length" class="game-card-players ps-2">
       <DetailText class="detail-text">Partida con {{ countPlayers() }} jugadorxs</DetailText>
       <DetailText class="detail-text">Ganó {{ getWinner() }}</DetailText>
+    </v-card-item>
+
+    <!-- edge case where the card has no players attached -->
+    <v-card-item v-else class="game-card-players ps-2">
+      <DetailText class="detail-text">{{ GAME_CARD_TEXT.NO_PLAYERS }}</DetailText>
     </v-card-item>
 
     <v-divider></v-divider>
@@ -77,6 +83,7 @@ const getWinner = () => {
 
         <div class="players-list mb-2">
           <ul
+            v-if="game.players?.length"
             v-for="player in game.players"
             :key="player.player_id"
           >
@@ -95,6 +102,7 @@ const getWinner = () => {
               </div>
             </li>
           </ul>
+          <DetailText v-else class="detailText">{{ GAME_CARD_TEXT.NO_PLAYERS }}</DetailText>
         </div>
 
         <v-card-item v-if="game.notes" class="game-card-notes">

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -32,7 +32,7 @@ const getWinner = () => {
 
 <template>
   <v-card
-    class="game-card"
+    class="game-card h-100"
     variant="elevated"
     hover
   >
@@ -126,6 +126,7 @@ const getWinner = () => {
   flex-direction: column;
   align-items: self-start;
   padding: 12px;
+  justify-content: space-between;
 }
 
 .game-card-date,
@@ -147,6 +148,7 @@ const getWinner = () => {
   display: flex;
   justify-content: space-between;
   width: 100%;
+
 }
 
 .detail-text {

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -36,17 +36,19 @@ const getWinner = () => {
     variant="elevated"
     hover
   >
-    <v-card-title class="ps-2">
-      <CardHeading class="mb-n3">
-        {{ game.boardgame_name }}
-      </CardHeading>
-    </v-card-title>
-
-    <v-card-subtitle v-if="game.start_date" class="game-card-date ps-2">
-      <DetailText>
-        {{ formatDate(game.start_date) }}
-      </DetailText>
-    </v-card-subtitle>
+    <div>
+      <v-card-title class="ps-2">
+        <CardHeading class="mb-n3">
+          {{ game.boardgame_name }}
+        </CardHeading>
+      </v-card-title>
+  
+      <v-card-subtitle v-if="game.start_date" class="game-card-date ps-2">
+        <DetailText>
+          {{ formatDate(game.start_date) }}
+        </DetailText>
+      </v-card-subtitle>
+    </div>
 
     <v-card-item v-if="game.players?.length" class="game-card-players ps-2">
       <DetailText class="detail-text">Partida con {{ countPlayers() }} jugadorxs</DetailText>

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -25,7 +25,7 @@ const countPlayers = () => {
 
 const getWinner = () => {
   const winner = props.game.players.find((player) => player.is_winner);
-  return winner.player_name ?? "Desconocido";
+  return winner.player_name ?? GAME_CARD_TEXT.NO_WINNER;
 }
 
 </script>
@@ -51,8 +51,8 @@ const getWinner = () => {
     </div>
 
     <v-card-item v-if="game.players?.length" class="game-card-players ps-2">
-      <DetailText class="detail-text">Partida con {{ countPlayers() }} jugadorxs</DetailText>
-      <DetailText class="detail-text">Ganó {{ getWinner() }}</DetailText>
+      <DetailText class="detail-text">{{ GAME_CARD_TEXT.PLAYERS_COUNT_TEXT(countPlayers()) }}</DetailText>
+      <DetailText class="detail-text">{{ GAME_CARD_TEXT.WINNER_TEXT(getWinner()) }}</DetailText>
     </v-card-item>
 
     <!-- edge case where the card has no players attached -->

--- a/src/composables/useGamesApi.ts
+++ b/src/composables/useGamesApi.ts
@@ -9,6 +9,10 @@ export function useGamesApi() {
   const errorSaveGame: Ref<string | null> = ref(null);
   const errorGetGames: Ref<string | null> = ref(null);
 
+  const currentPage: Ref<number> = ref(1);
+  const itemsPerPage: Ref<number> = ref(12);
+  const totalPages: Ref<number> = ref(0);
+
   const saveGame = async (gameData: CreateGameRequest) => {
     loading.value =  true;
     errorSaveGame.value = null;
@@ -25,13 +29,18 @@ export function useGamesApi() {
     }
   }
 
-  const getGames = async () => {
+  const getGames = async (limit?: number, offset?: number) => {
     loading.value = true;
     errorGetGames.value = null;
 
     try {
-      const response = await GamesApiService.getGames();
+      const response = await GamesApiService.getGames(
+        limit ?? itemsPerPage.value,
+        offset ?? (currentPage.value - 1) * itemsPerPage.value
+      );
       gamesList.value = response;
+      console.log(gamesList.value);
+      totalPages.value = Math.ceil(response.total / response.limit);
       return response;
     } catch (err) {
       errorGetGames.value = err.message;
@@ -41,5 +50,5 @@ export function useGamesApi() {
     }
   }
 
-  return { loading, newGame, errorSaveGame, gamesList, errorGetGames, saveGame, getGames }
+  return { loading, newGame, errorSaveGame, gamesList, errorGetGames, currentPage, totalPages, itemsPerPage, saveGame, getGames }
 }

--- a/src/constants/ui_text/GameCard.ts
+++ b/src/constants/ui_text/GameCard.ts
@@ -1,3 +1,6 @@
 export const GAME_CARD_TEXT = {
-  NO_PLAYERS: "No hay jugadores registrados"
+  NO_PLAYERS: "No hay jugadores registrados",
+  NO_WINNER: "Desconocido",
+  PLAYERS_COUNT_TEXT: (amount: number) => `Partida con ${amount} jugadorxs`,
+  WINNER_TEXT: (player: string) => `Ganó ${player}`,
 }

--- a/src/constants/ui_text/GameCard.ts
+++ b/src/constants/ui_text/GameCard.ts
@@ -1,0 +1,3 @@
+export const GAME_CARD_TEXT = {
+  NO_PLAYERS: "No hay jugadores registrados"
+}

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -12,18 +12,24 @@ defineOptions({ name: "GamesView" });
 
 useDocumentTitle(DOCUMENT_TITLES.GAMES);
 
-const { loading, gamesList, errorGetGames, getGames } = useGamesApi();
+const { loading, gamesList, errorGetGames, currentPage, totalPages, itemsPerPage, getGames } = useGamesApi();
 
 onBeforeMount(async () => {
   await getGames();
   console.log(gamesList.value);
   console.log(errorGetGames.value);
+  console.log(totalPages.value);
 })
+
+const onPageChange = async () => {
+  await getGames();
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
 
 </script>
 
 <template>
-  <v-container class="mt-4">
+  <v-container class="my-4">
     <DisplayTitle>Partidas</DisplayTitle>
 
     <!-- error on games initial fetch -->
@@ -47,6 +53,18 @@ onBeforeMount(async () => {
       <v-col>
         <SubsectionTitle>{{ GENERAL_UI_TEXT.NO_DATA_GAMES_TITLE }}</SubsectionTitle>
         <BodyText>{{ GENERAL_UI_TEXT.NO_DATA_GAMES_CTA }}</BodyText>
+      </v-col>
+    </v-row>
+
+    <!-- pagination -->
+    <v-row v-if="totalPages > 1 && !loading" class="mt-4">
+      <v-col>
+        <v-pagination
+          v-model="currentPage"
+          :length="totalPages"
+          @update:modelValue="onPageChange"
+          :disabled="loading"
+        />
       </v-col>
     </v-row>
 


### PR DESCRIPTION
Objetivo: Agregar paginación a la vista de GamesView.

## Cambios realizados
- Refactor de useGamesApi.ts para que maneje la paginación. Expone refs currentPage, totalPages e itemsPerPage para que el componente utilice
- Implementada paginación en GamesView
- Fix en GameCard para que acepte que no haya jugadores en una partida. Esto viene de una de las partidas de prueba iniciales antes de que la API requiriera a los jugadores para guardar la partida. 
- Fixes de estilo para que GameCard mantenga el mismo layout en el caso de no tener info de jugadores y ganador 
- Movidos textos que se usan en GameCard a constantes

Closes #176 