### PR TITLE
Feature: Agregar información adicional a BoardgameCard

### DIFF
--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faUserGroup, faClock } from "@fortawesome/free-solid-svg-icons";
 import CardHeading from '@/components/atoms/typography/CardHeading.vue';
 import AppButton from '@/components/atoms/buttons/AppButton.vue';
 import { BUTTONS_TEXT } from '@/constants/buttonsText';
+import DetailText from '../atoms/typography/DetailText.vue';
+import { BOARDGAME_CARD_TEXT } from '@/constants/ui_text/BoardGameCard';
+
 
 const props = defineProps<{
   boardgame: CollectionsApiResponse
@@ -26,11 +29,28 @@ const emit = defineEmits<{
     hover
   >
 
-    <v-card-title class="ps-2">
-      <CardHeading>
-        {{ boardgame.name }}
-      </CardHeading>
-    </v-card-title>
+    <div>
+      <v-card-title class="ps-2">
+        <CardHeading class="mb-n1">
+          {{ boardgame.name }}
+        </CardHeading>
+      </v-card-title>
+  
+      <v-card-subtitle class="ps-2">
+        <DetailText>{{ boardgame.description }}</DetailText>
+      </v-card-subtitle>
+    </div>
+
+    <div class="ps-2 py-3 boardgame-card-info">
+      <div class="mb-1">
+        <FontAwesomeIcon :icon="faUserGroup" class="me-1" />
+        <DetailText>{{ BOARDGAME_CARD_TEXT.MIN_MAX_PLAYERS(boardgame.min_players, boardgame.max_players) }}</DetailText>
+      </div>
+      <div class="playtime-item">
+        <FontAwesomeIcon :icon="faClock" class="me-1" />
+        <DetailText>{{ BOARDGAME_CARD_TEXT.PLAYING_TIME(boardgame.playing_time) }}</DetailText>
+      </div>
+    </div>
 
     <v-card-actions>
       <AppButton
@@ -55,4 +75,24 @@ const emit = defineEmits<{
   padding: 12px;
 }
 
+.boardgame-card-info {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 750px) {
+  .boardgame-card-info {
+    flex-direction: row;
+  }
+
+  .playtime-item {
+    margin-left: 16px;
+  }
+}
+
+@media (min-width: 1146px) {
+  .playtime-item {
+    margin-left: 24px;
+  }
+}
 </style>

--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -7,7 +7,7 @@ import AppButton from '@/components/atoms/buttons/AppButton.vue';
 import { BUTTONS_TEXT } from '@/constants/buttonsText';
 import DetailText from '../atoms/typography/DetailText.vue';
 import { BOARDGAME_CARD_TEXT } from '@/constants/ui_text/BoardGameCard';
-
+import { getBoardgameComplexity } from '@/utils/boardgame';
 
 const props = defineProps<{
   boardgame: CollectionsApiResponse
@@ -35,13 +35,13 @@ const emit = defineEmits<{
           {{ boardgame.name }}
         </CardHeading>
       </v-card-title>
-  
+
       <v-card-subtitle class="ps-2">
         <DetailText>{{ boardgame.description }}</DetailText>
       </v-card-subtitle>
     </div>
 
-    <div class="ps-2 py-3 boardgame-card-info">
+    <div class="ps-2 pt-3 pb-2 boardgame-card-info">
       <div class="mb-1">
         <FontAwesomeIcon :icon="faUserGroup" class="me-1" />
         <DetailText>{{ BOARDGAME_CARD_TEXT.MIN_MAX_PLAYERS(boardgame.min_players, boardgame.max_players) }}</DetailText>
@@ -50,6 +50,12 @@ const emit = defineEmits<{
         <FontAwesomeIcon :icon="faClock" class="me-1" />
         <DetailText>{{ BOARDGAME_CARD_TEXT.PLAYING_TIME(boardgame.playing_time) }}</DetailText>
       </div>
+    </div>
+
+    <div class="ps-2 pb-3">
+      <v-chip>
+        <DetailText>{{ getBoardgameComplexity(boardgame.complexity) }}</DetailText>
+      </v-chip>
     </div>
 
     <v-card-actions>

--- a/src/constants/ui_text/BoardGameCard.ts
+++ b/src/constants/ui_text/BoardGameCard.ts
@@ -1,0 +1,4 @@
+export const BOARDGAME_CARD_TEXT = {
+  MIN_MAX_PLAYERS: (min: number, max: number) => `${min} a ${max} jugadorxs`,
+  PLAYING_TIME: (time: number) => `${time} minutos`,
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
   faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare,
   faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck,
   faCheckSquare, faCalendar, faChevronLeft, faChevronRight, faChevronDown,
-  faChevronUp, faFloppyDisk, faCircleCheck, faTrophy
+  faChevronUp, faFloppyDisk, faCircleCheck, faTrophy, faUserGroup, faClock
 } from "@fortawesome/free-solid-svg-icons";
 import { VDateInput } from "vuetify/labs/VDateInput";
 
@@ -146,7 +146,7 @@ library.add(
   faDice, faUsers, faBoxArchive, faBars, faSun, faMoon, faTrash, faPenToSquare,
   faPlus, faTriangleExclamation, faSquare, faCaretDown, faCheck, faCheckSquare,
   faCalendar, faChevronLeft, faChevronRight, faChevronDown, faChevronUp,
-  faFloppyDisk, faCircleCheck, faTrophy
+  faFloppyDisk, faCircleCheck, faTrophy, faUserGroup, faClock
 );
 
 // Initialize app

--- a/src/utils/boardgame.ts
+++ b/src/utils/boardgame.ts
@@ -1,0 +1,5 @@
+export const getBoardgameComplexity = (complexity: number) => {
+  if(complexity <=2) return "Juego casual";
+  if(complexity <=3.5) return "Para jugadorxs habituales";
+  return "Para jugadorxs experimentados"
+}


### PR DESCRIPTION
## Objetivo
Mostrar detalles de cada boardgame en BoardgameCard: descripción, número de jugadores, duración de la partida, complejidad del juego. 

## Cambios realizados
- Agregada la información requerida al componente BoardgameCard. No se avanzó con la idea de hacer un desplegable para mostrar la info, es poco texto y se puede mostrar en la card
- Creada función util getBoardgameComplexity para definir la complejidad del juego
- Agregadas constantes para los textos de info que se muestran en el componente

Closes #167 