### PR TITLE
Style: nuevo componente de tipografía CardInfo 

### DIFF
--- a/src/components/atoms/typography/CardInfo.vue
+++ b/src/components/atoms/typography/CardInfo.vue
@@ -15,14 +15,12 @@ defineOptions({ name: "CardInfo" });
   font-size: var(--font-size-xxs);
   font-weight: 500;
   line-height: 1;
-  display: block;
 }
 
-/* @media(min-width: 960px) {
+@media(min-width: 961px) {
   .card-info {
     font-size: var(--font-size-xs);
   }
-} */
-
+}
 
 </style>

--- a/src/components/atoms/typography/CardInfo.vue
+++ b/src/components/atoms/typography/CardInfo.vue
@@ -1,0 +1,28 @@
+<!-- src/components/atoms/CardInfo.vue -->
+<template>
+  <span class="card-info">
+    <slot />
+  </span>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: "CardInfo" });
+</script>
+
+<style scoped>
+.card-info {
+  font-family: var(--font-text);
+  font-size: var(--font-size-xxs);
+  font-weight: 500;
+  line-height: 1;
+  display: block;
+}
+
+/* @media(min-width: 960px) {
+  .card-info {
+    font-size: var(--font-size-xs);
+  }
+} */
+
+
+</style>

--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -8,6 +8,7 @@ import { BUTTONS_TEXT } from '@/constants/buttonsText';
 import DetailText from '../atoms/typography/DetailText.vue';
 import { BOARDGAME_CARD_TEXT } from '@/constants/ui_text/BoardGameCard';
 import { getBoardgameComplexity } from '@/utils/boardgame';
+import CardInfo from '../atoms/typography/CardInfo.vue';
 
 const props = defineProps<{
   boardgame: CollectionsApiResponse
@@ -44,17 +45,17 @@ const emit = defineEmits<{
     <div class="ps-2 pt-3 pb-2 boardgame-card-info">
       <div class="mb-1">
         <FontAwesomeIcon :icon="faUserGroup" class="me-1" />
-        <DetailText>{{ BOARDGAME_CARD_TEXT.MIN_MAX_PLAYERS(boardgame.min_players, boardgame.max_players) }}</DetailText>
+        <CardInfo>{{ BOARDGAME_CARD_TEXT.MIN_MAX_PLAYERS(boardgame.min_players, boardgame.max_players) }}</CardInfo>
       </div>
       <div class="playtime-item">
         <FontAwesomeIcon :icon="faClock" class="me-1" />
-        <DetailText>{{ BOARDGAME_CARD_TEXT.PLAYING_TIME(boardgame.playing_time) }}</DetailText>
+        <CardInfo>{{ BOARDGAME_CARD_TEXT.PLAYING_TIME(boardgame.playing_time) }}</CardInfo>
       </div>
     </div>
 
     <div class="ps-2 pb-3">
       <v-chip>
-        <DetailText>{{ getBoardgameComplexity(boardgame.complexity) }}</DetailText>
+        <CardInfo>{{ getBoardgameComplexity(boardgame.complexity) }}</CardInfo>
       </v-chip>
     </div>
 

--- a/src/components/molecules/BoardgameCard.vue
+++ b/src/components/molecules/BoardgameCard.vue
@@ -87,6 +87,8 @@ const emit = defineEmits<{
   flex-direction: column;
 }
 
+
+
 @media (min-width: 750px) {
   .boardgame-card-info {
     flex-direction: row;
@@ -102,4 +104,9 @@ const emit = defineEmits<{
     margin-left: 24px;
   }
 }
+
+:deep(.v-card--hover) {
+  cursor: default;
+}
+
 </style>

--- a/src/components/molecules/GameCard.vue
+++ b/src/components/molecules/GameCard.vue
@@ -32,7 +32,7 @@ const getWinner = () => {
 
 <template>
   <v-card
-    class="game-card h-100"
+    class="game-card"
     variant="elevated"
     hover
   >
@@ -58,6 +58,7 @@ const getWinner = () => {
     <!-- edge case where the card has no players attached -->
     <v-card-item v-else class="game-card-players ps-2">
       <DetailText class="detail-text">{{ GAME_CARD_TEXT.NO_PLAYERS }}</DetailText>
+      <DetailText class="hidden-text">-</DetailText>
     </v-card-item>
 
     <v-divider></v-divider>
@@ -167,6 +168,10 @@ const getWinner = () => {
 
 .player-item .detail-text {
   margin-bottom: 0px;
+}
+
+.hidden-text {
+  visibility: hidden;
 }
 
 @media only screen and (min-width: 600px) and (max-width: 960px) {

--- a/src/components/molecules/TypographyChart.vue
+++ b/src/components/molecules/TypographyChart.vue
@@ -13,6 +13,7 @@ import CaptionText from '@/components/atoms/typography/CaptionText.vue';
 import ButtonLabel from '@/components/atoms/typography/ButtonLabel.vue';
 import NavigationLink from '@/components/atoms/typography/NavigationLink.vue';
 import ExternalLink from '@/components/atoms/typography/ExternalLink.vue';
+import CardInfo from '@/components/atoms/typography/CardInfo.vue';
 
 </script>
 
@@ -99,6 +100,12 @@ import ExternalLink from '@/components/atoms/typography/ExternalLink.vue';
           <td><ButtonLabel>Button Label</ButtonLabel></td>
           <td>Button label</td>
           <td>AppButton, AppSnackbar</td>
+        </tr>
+        <tr>
+          <td>Span</td>
+          <td><CardInfo>Card Info</CardInfo></td>
+          <td>Details in Card</td>
+          <td>BoardGameCard, </td>
         </tr>
         <tr>
           <td>Span</td>


### PR DESCRIPTION
Usar DetailText para mostrar la información en BoardgameCard hace que los diferentes textos queden muy homogéneos y se pierda la jerarquía de información.

Un nuevo componente, CardInfo mantendría el tamaño de BottomNavLabel, sin uppercase y sin los estilos necesarios para que sean correctamente visibles en un AppBar.

## Cambios realizados
- Creado componente CardInfo
- Refactor de BoardgameCard para mostrar la info adicional con CardInfo
- Agregado CardInfo a Typography chart
- Refactor de GameCard, el fix de h-100 en caso de que no haya jugadores estaba rompiendo todas las cards

Closes #200 