### PR TITLE
Test: Agregar tests para gameApiService.ts y useGamesApi.ts

### DIFF
--- a/src/api/gameApiService.spec.ts
+++ b/src/api/gameApiService.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, vi, afterEach, beforeEach, expect } from "vitest";
-import { mockNewGameRequest, mockCreatedGameResponse } from "../mocks/data/gameApi";
+import { mockNewGameRequest, mockCreatedGameResponse } from "@/mocks/data/gameApi";
 import { createGame } from "./gameApiService";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 

--- a/src/api/gameApiService.spec.ts
+++ b/src/api/gameApiService.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, vi, afterEach, beforeEach, expect } from "vitest";
+import { mockNewGameRequest, mockCreatedGameResponse } from "../mocks/data/gameApi";
+import { createGame } from "./gameApiService";
+import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+describe("gameApiService: createGame()", ()=> {
+  afterEach(()=> {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  })
+
+  it("success: creates new game", async ()=> {
+    // use spyOn to mock on global fetch
+    // on the spyOn
+    //  set the mockResolvedValue to the response
+    // call the function in the composable
+    // await the result
+    // check if tested function was called once and the paylod matches
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async ()=> mockCreatedGameResponse
+    } as unknown as Response);
+
+    const result = await createGame(mockNewGameRequest);
+
+    expect(result).toEqual(mockCreatedGameResponse);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(`${API_BASE_URL}v1/games`, {
+      method: "POST",
+      headers: { 'Content-Type': 'application/json', },
+      body: JSON.stringify(mockNewGameRequest)
+    })
+  });
+
+  it("error: bad request (400)", async ()=> {
+    // use spyOn to mock global fetch
+    // mockResolvedValue con el ok false y status 400
+    // call function to test and await result
+    // check if it was called once and payload matches
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false, 
+      status: 400,
+    } as unknown as Response);
+    
+    await expect(createGame(mockNewGameRequest)).rejects.toThrow(API_ERROR_MESSAGES.CREATE_GAME_ERROR(400));
+  });
+
+  it("error: internal server error (500)", async ()=> {
+    // spyOn mock global fetch
+    // mockResolvedValue ok false y status 500
+    // call function and await result
+    // check called once and payload matches
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as unknown as Response);
+
+    await expect(createGame(mockNewGameRequest)).rejects.toThrow(API_ERROR_MESSAGES.CREATE_GAME_ERROR(500));
+  });
+
+  it("error: network error", async ()=> {
+    // spyOn mock global fetch
+    // mockRejectedValue with throw New Error network
+    // call function and await result
+    // check called once and paylod matches
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error(API_ERROR_MESSAGES.NETWORK_ERROR));
+
+    await expect(createGame(mockNewGameRequest)).rejects.toThrow(API_ERROR_MESSAGES.NETWORK_ERROR);
+  });
+})

--- a/src/composables/useGamesApi.spec.ts
+++ b/src/composables/useGamesApi.spec.ts
@@ -1,0 +1,113 @@
+import { it, vi, describe, afterEach, expect } from "vitest";
+import * as GamesApiService from "../api/gameApiService";
+import { useGamesApi } from "./useGamesApi";
+import { mockNewGameRequest, mockCreatedGameResponse } from "../mocks/data/gameApi";
+import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
+import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "../tests/utils/apiComposables";
+
+describe("useGamesApi", ()=> {
+  afterEach(()=> {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe("saveGame", ()=> {
+
+    it.only("success: saves new game, updates loading, no errors", async () => {
+      // mockear respuesta del saved game
+      // desestructurar useGamesApi con lo que necesito
+      // check shared initial status
+      // check que newGame sea null
+      // hacer llamada a saveGame
+      // check shared loading status
+      // await la llamada
+      // check shared end status
+      // confirmar que new game sea igual a la rta mockeada
+      // confirmar error en null
+      const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockResolvedValueOnce(mockCreatedGameResponse);
+      const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
+
+      expectSharedInitialState(loading.value, errorSaveGame.value);
+      expect(newGame.value).toBeNull();
+
+      const result = saveGame(mockNewGameRequest);
+      expectLoadingState(loading.value, errorSaveGame.value);
+
+      await result;
+
+      expectSharedEndState(spyCreateGame, loading.value);
+      expect(newGame.value).toEqual(mockCreatedGameResponse);
+      expect(errorSaveGame.value).toBeNull();
+    });
+
+    // para casos de error
+    // mockear rta rejected con throw error correspondiente
+    // desestructurar useGamesApi
+    // expect initial state y que newGame sea null
+    // guardar llamada a saveGame en const
+    // expect loading state
+    // await llamada en un try/catch
+    // expect end state
+    // confirmar que el error sea el mismo
+    // confirmar que newGame sea null
+    it.only("error: bad request (400)", async () => {
+      const errorMessage = API_ERROR_MESSAGES.CREATE_GAME_ERROR(400);
+      const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValue(new Error(errorMessage));
+      const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
+
+      expectSharedInitialState(loading.value, errorSaveGame.value);
+      expect(newGame.value).toBeNull();
+
+      const response = saveGame(mockNewGameRequest);
+      expectLoadingState(loading.value, errorSaveGame.value);
+
+      try {
+        await response;
+      } catch (error) {}
+
+      expectSharedEndState(spyCreateGame, loading.value);
+      expect(errorSaveGame.value).toBe(errorMessage);
+      expect(newGame.value).toBeNull();
+    });
+
+    it.only("error: internal server error (500)", async () => {
+      const errorMessage = API_ERROR_MESSAGES.CREATE_GAME_ERROR(500);
+      const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValueOnce(new Error(errorMessage));
+      const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
+
+      expectSharedInitialState(loading.value, errorSaveGame.value);
+      expect(newGame.value).toBeNull();
+
+      const response = saveGame(mockNewGameRequest);
+      expectLoadingState(loading.value, errorSaveGame.value);
+
+      try {
+        await response;
+      } catch (error) {};
+
+      expectSharedEndState(spyCreateGame, loading.value);
+      expect(errorSaveGame.value).toBe(errorMessage);
+      expect(newGame.value).toBeNull();
+    });
+
+    it.only("error: network error ", async () => {
+      const errorMessage = API_ERROR_MESSAGES.NETWORK_ERROR;
+      const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValueOnce(new Error(errorMessage));
+      const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
+
+      expectSharedInitialState(loading.value, errorSaveGame.value);
+      expect(newGame.value).toBeNull();
+
+      const response = saveGame(mockNewGameRequest);
+      expectLoadingState(loading.value, errorSaveGame.value);
+
+      try {
+       await response; 
+      } catch (error) { };
+
+      expectSharedEndState(spyCreateGame, loading.value);
+      expect(errorSaveGame.value).toBe(errorMessage);
+      expect(newGame.value).toBeNull();
+    });
+  })
+})

--- a/src/composables/useGamesApi.spec.ts
+++ b/src/composables/useGamesApi.spec.ts
@@ -13,7 +13,7 @@ describe("useGamesApi", ()=> {
 
   describe("saveGame", ()=> {
 
-    it.only("success: saves new game, updates loading, no errors", async () => {
+    it("success: saves new game, updates loading, no errors", async () => {
       // mockear respuesta del saved game
       // desestructurar useGamesApi con lo que necesito
       // check shared initial status
@@ -50,7 +50,7 @@ describe("useGamesApi", ()=> {
     // expect end state
     // confirmar que el error sea el mismo
     // confirmar que newGame sea null
-    it.only("error: bad request (400)", async () => {
+    it("error: bad request (400)", async () => {
       const errorMessage = API_ERROR_MESSAGES.CREATE_GAME_ERROR(400);
       const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValue(new Error(errorMessage));
       const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
@@ -70,7 +70,7 @@ describe("useGamesApi", ()=> {
       expect(newGame.value).toBeNull();
     });
 
-    it.only("error: internal server error (500)", async () => {
+    it("error: internal server error (500)", async () => {
       const errorMessage = API_ERROR_MESSAGES.CREATE_GAME_ERROR(500);
       const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValueOnce(new Error(errorMessage));
       const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
@@ -90,7 +90,7 @@ describe("useGamesApi", ()=> {
       expect(newGame.value).toBeNull();
     });
 
-    it.only("error: network error ", async () => {
+    it("error: network error ", async () => {
       const errorMessage = API_ERROR_MESSAGES.NETWORK_ERROR;
       const spyCreateGame = vi.spyOn(GamesApiService, "createGame").mockRejectedValueOnce(new Error(errorMessage));
       const { loading, errorSaveGame, newGame, saveGame } = useGamesApi();
@@ -102,7 +102,7 @@ describe("useGamesApi", ()=> {
       expectLoadingState(loading.value, errorSaveGame.value);
 
       try {
-       await response; 
+       await response;
       } catch (error) { };
 
       expectSharedEndState(spyCreateGame, loading.value);

--- a/src/composables/useGamesApi.spec.ts
+++ b/src/composables/useGamesApi.spec.ts
@@ -1,9 +1,9 @@
 import { it, vi, describe, afterEach, expect } from "vitest";
-import * as GamesApiService from "../api/gameApiService";
+import * as GamesApiService from "@/api/gameApiService";
 import { useGamesApi } from "./useGamesApi";
-import { mockNewGameRequest, mockCreatedGameResponse } from "../mocks/data/gameApi";
-import { API_ERROR_MESSAGES } from "../constants/apiErrorMessages";
-import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "../tests/utils/apiComposables";
+import { mockNewGameRequest, mockCreatedGameResponse } from "@/mocks/data/gameApi";
+import { API_ERROR_MESSAGES } from "@/constants/apiErrorMessages";
+import { expectSharedInitialState, expectLoadingState, expectSharedEndState } from "@/tests/utils/apiComposables";
 
 describe("useGamesApi", ()=> {
   afterEach(()=> {

--- a/src/mocks/data/gameApi.ts
+++ b/src/mocks/data/gameApi.ts
@@ -1,0 +1,32 @@
+import { CreateGameRequest, CreatedGameResponse } from "../../types/domain/gamesApi"
+
+export const mockNewGameRequest: CreateGameRequest = {
+  boardgame_id: "bcae2afc-f027-489d-8f70-fd8f79d10533",
+  collection_id: "b6acc73a-6b7a-4c67-937a-e1a6169f173f",
+  player_group_id: null,
+  start_date: "2026-01-16T15:48:47.565840519Z",
+  end_date: null,
+  notes: "Guardando una nueva partida",
+  players: [
+    {
+      player_id: "3a28cf09-0506-4d1d-aba7-414702eb690c",
+      is_winner: true,
+    },
+    {
+      player_id: "2b0164f7-1a93-491e-aced-ba04c4034157",
+      is_winner: false,
+    }
+  ]
+}
+
+export const mockCreatedGameResponse: CreatedGameResponse = { 
+  id: "6b4ae664-0086-49c6-b938-2fc56cdb55e8",
+  boardgame_id: "bcae2afc-f027-489d-8f70-fd8f79d10533",
+  collection_id: "b6acc73a-6b7a-4c67-937a-e1a6169f173f",
+  start_date: "2026-01-16T15:48:47.565840519Z",
+  end_date: null,
+  notes: "Guardando una nueva partida",
+  duration: "2h15m0s",
+  created_at: "2026-01-16T15:48:47.565840519Z",
+  updated_at: "2026-01-16T15:48:47.565840519Z"
+}

--- a/src/mocks/data/gameApi.ts
+++ b/src/mocks/data/gameApi.ts
@@ -1,4 +1,4 @@
-import { CreateGameRequest, CreatedGameResponse } from "../../types/domain/gamesApi"
+import { CreateGameRequest, CreatedGameResponse } from "@/types/domain/gamesApi"
 
 export const mockNewGameRequest: CreateGameRequest = {
   boardgame_id: "bcae2afc-f027-489d-8f70-fd8f79d10533",

--- a/src/mocks/data/gameApi.ts
+++ b/src/mocks/data/gameApi.ts
@@ -10,10 +10,12 @@ export const mockNewGameRequest: CreateGameRequest = {
   players: [
     {
       player_id: "3a28cf09-0506-4d1d-aba7-414702eb690c",
+      player_name: "Zeuchi",
       is_winner: true,
     },
     {
       player_id: "2b0164f7-1a93-491e-aced-ba04c4034157",
+      player_name: "Mareita",
       is_winner: false,
     }
   ]

--- a/src/types/domain/gamesApi.ts
+++ b/src/types/domain/gamesApi.ts
@@ -36,3 +36,15 @@ export interface CreateGameRequest {
   notes: string,
   players: PlayerInGame[],
 }
+
+export interface CreatedGameResponse {
+  id: string,
+  boardgame_id: string,
+  collection_id: string,
+  start_date: string,
+  end_date: string,
+  notes: string,
+  duration: string,
+  created_at: string,
+  updated_at: string,
+}


### PR DESCRIPTION
En #136 hice los tests para gameApiService.ts y useGameApi.ts, quedaba pendiente el test para AddGameDialog.vue.

La rama test/testing-save-new-game-feature donde estaba trabajando quedó muy atrasada con respecto a main. Hice un pull de main pero quedó con conflictos y la rama se rompió. En vez de resolver esa rama, traje los archivos de tests más los mocks e interface creados para los tests a una rama nueva. 

Mergeo estos tests con main para que ya queden dentro de los tests existentes. El test pendiente se está trackeando en #154 

Closes #136 