### PR TITLE
Test: Tests pendientes de AddGameDialog.vue

### DIFF
--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -4,7 +4,7 @@ import { nextTick } from "vue";
 import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
 import { setTextInputValue } from "@/tests/utils/form-helpers";
 import AddGameDialog from "@/components/organisms/AddGameDialog.vue";
-import { VDialog, VCard, VSelect, VTextarea, VBtn, VAlert, VRow, VCol } from "vuetify/components";
+import { VDialog, VCard, VSelect, VTextarea, VBtn, VAlert, VRow, VCol, VCardTitle, VCardSubtitle, VCardItem, VForm, VCardText, VCardActions } from "vuetify/components";
 import { VDateInput } from "vuetify/labs/VDateInput";
 import { AddGameDialogText } from "@/constants/ui_text/AddGameDialog";
 import type { CollectionsApiResponse } from "@/types/domain/collectionsApi";
@@ -17,15 +17,7 @@ vi.mock("@/composables/usePlayersApi");
 vi.mock("@/composables/useGamesApi");
 
 const vuetify = createVuetifyForTest({
-  VDialog,
-  VCard,
-  VSelect,
-  VDateInput,
-  VTextarea,
-  VBtn,
-  VAlert,
-  VRow,
-  VCol
+  VDialog, VCard, VSelect, VDateInput, VTextarea, VBtn, VAlert, VRow, VCol, VCardTitle, VCardSubtitle, VCardItem, VForm, VCardText, VCardActions
 });
 
 
@@ -41,9 +33,10 @@ const mountAddGameDialog = (options: Record<string, any> = {}) => {
       plugins: [vuetify],
       stubs: {
         "v-dialog": {
-          template: `<div v-bind="$attrs" data-testid="add-game-dialog">
+          template: `<div v-if="modelValue" v-bind="$attrs" data-testid="add-game-dialog">
             <slot/>
           </div>`,
+          props: ["modelValue"],
           emits: ["update:modelValue"]
         },
         "v-date-input": {
@@ -138,16 +131,18 @@ const setupAddGameDialogTest = (options: Record<string, any> = {}) => {
   };
 };
 
-describe("AddGameDialog - Rendering", () => {
+describe("Rendering", () => {
+  let dialogContent;
+  let wrapper;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    ({ wrapper, dialogContent } = setupAddGameDialogTest());
   });
 
-  // TODO: Implement test 1.1
-  it("1.1 - Renderiza cuando modelValue es true", () => {
-    // Verificar que el dialog es visible
-    // Verificar que todos los campos están presentes
-  });
+  it.only("renders component when modelValue is true", () => {
+    expect(dialogContent.exists()).toBe(true);
+   });
 
   // TODO: Implement test 1.2
   it("1.2 - No renderiza cuando modelValue es false", () => {

--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -9,6 +9,8 @@ import { VDateInput } from "vuetify/labs/VDateInput";
 import { AddGameDialogText } from "@/constants/ui_text/AddGameDialog";
 import type { CollectionsApiResponse } from "@/types/domain/collectionsApi";
 import type { PlayerApiResponse } from "@/types/domain/playerApi";
+import { mockCollectionsApiResponse } from "@/mocks/data/collectionsApi";
+import { mockPlayersListResponse } from "@/mocks/data/playersApi";
 
 // Mock composables
 vi.mock("@/composables/usePlayersApi");
@@ -26,29 +28,13 @@ const vuetify = createVuetifyForTest({
   VCol
 });
 
-// Mock data
-const mockBoardgame: CollectionsApiResponse = {
-  id: "game-123",
-  name: "Catan",
-  bgg_id: 333,
-  min_players: 2,
-  max_players: 4,
-  playing_time: 90,
-  complexity: 1.1,
-};
-
-const mockPlayers: PlayerApiResponse[] = [
-  { id: "player-1", name: "Jugador 1", is_registered: true },
-  { id: "player-2", name: "Jugador 2", is_registered: true },
-  { id: "player-3", name: "Jugador 3", is_registered: false },
-];
 
 // Mount function
 const mountAddGameDialog = (options: Record<string, any> = {}) => {
   return mount(AddGameDialog, {
     props: {
       modelValue: true,
-      boardgame: mockBoardgame,
+      boardgame: mockCollectionsApiResponse,
       ...options.props || {},
     },
     global: {

--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -11,6 +11,9 @@ import type { CollectionsApiResponse } from "@/types/domain/collectionsApi";
 import type { PlayerApiResponse } from "@/types/domain/playerApi";
 import { mockCollectionsApiResponse } from "@/mocks/data/collectionsApi";
 import { mockPlayersListResponse } from "@/mocks/data/playersApi";
+import { usePlayerApi } from "@/composables/usePlayerApi";
+import { usePlayersApi } from "@/composables/usePlayersApi";
+import { ref } from "vue";
 
 // Mock composables
 vi.mock("@/composables/usePlayersApi");
@@ -125,17 +128,17 @@ const setupAddGameDialogTest = (options: Record<string, any> = {}) => {
 describe("Rendering", () => {
   let dialogContent;
   let wrapper;
+  let loadingRow;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    ({ wrapper, dialogContent } = setupAddGameDialogTest());
+    ({ wrapper, dialogContent, loadingRow } = setupAddGameDialogTest());
   });
 
   it.only("renders component when modelValue is true", () => {
     expect(dialogContent.exists()).toBe(true);
    });
 
-  // test 1.2
   it.only("doesn't render component when modelValue is false", () => {
     const { dialogContent } = setupAddGameDialogTest({
       props: { modelValue: false },
@@ -144,10 +147,21 @@ describe("Rendering", () => {
     expect(dialogContent.exists()).toBe(false);
   });
 
-  // TODO: Implement test 1.3
-  it("1.3 - Muestra loading state", () => {
-    // Verificar que cuando loading=true, muestra LoadingRow
-    // Verificar que oculta el formulario
+  it.only("when loading is true, renders LoadingRow and doesn't render dialog", () => {
+    vi.mocked(usePlayersApi).mockReturnValue({
+      players: ref([]),
+      totalPlayers: ref(0),
+      loading: ref(true),
+      error: ref(null),
+      fetchPlayers: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    // the dialog is always visible when modelValue is true
+    // it's hidden by adding the class .hidden-on-loading to the content wrapper
+    const contentWrapper = wrapper.find(".content-wrapper");
+
+    expect(loadingRow.exists()).toBe(true);
+    expect(contentWrapper.classes()).toContain("hidden-on-loading");
   });
 
   // TODO: Implement test 1.4

--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -129,17 +129,23 @@ describe("Rendering", () => {
   let dialogContent;
   let wrapper;
   let loadingRow;
+  let dateInput;
+  let playersSelect;
+  let winnerSelect;
+  let notesTextarea;
+  let btnSave;
+  let btnCancel;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    ({ wrapper, dialogContent, loadingRow } = setupAddGameDialogTest());
+    ({ wrapper, dialogContent, loadingRow, dateInput, playersSelect, winnerSelect, notesTextarea, btnSave, btnCancel } = setupAddGameDialogTest());
   });
 
-  it.only("renders component when modelValue is true", () => {
+  it("renders component when modelValue is true", () => {
     expect(dialogContent.exists()).toBe(true);
    });
 
-  it.only("doesn't render component when modelValue is false", () => {
+  it("doesn't render component when modelValue is false", () => {
     const { dialogContent } = setupAddGameDialogTest({
       props: { modelValue: false },
     });
@@ -147,7 +153,7 @@ describe("Rendering", () => {
     expect(dialogContent.exists()).toBe(false);
   });
 
-  it.only("when loading is true, renders LoadingRow and doesn't render dialog", () => {
+  it("when loading is true, renders LoadingRow and doesn't render dialog", () => {
     vi.mocked(usePlayersApi).mockReturnValue({
       players: ref([]),
       totalPlayers: ref(0),
@@ -164,21 +170,12 @@ describe("Rendering", () => {
     expect(contentWrapper.classes()).toContain("hidden-on-loading");
   });
 
-  // TODO: Implement test 1.4
-  it("1.4 - Muestra error state (primer intento)", () => {
-    // Verificar que cuando error está presente y errorCount=1
-    // Muestra alerta con mensaje de reintento
-  });
-
-  // TODO: Implement test 1.5
-  it("1.5 - Muestra error state (segundo intento)", () => {
-    // Verificar que cuando errorCount>1
-    // Muestra mensaje de recargar página
-  });
-
-  // TODO: Implement test 1.6
-  it("1.6 - Renderiza todos los campos del formulario", () => {
-    // Verificar que están presentes:
-    // Date input, players select, winner select, notes textarea, botones
+  it("renders all input fields", () => {
+    expect(dateInput.exists()).toBe(true);
+    expect(playersSelect.exists()).toBe(true);
+    expect(winnerSelect.exists()).toBe(true);
+    expect(notesTextarea.exists()).toBe(true);
+    expect(btnSave.exists()).toBe(true);
+    expect(btnCancel.exists()).toBe(true);
   });
 });

--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -118,16 +118,7 @@ const setupAddGameDialogTest = (options: Record<string, any> = {}) => {
   const dialogContent = wrapper.find('[data-testid="add-game-dialog"]');
 
   return {
-    wrapper,
-    dateInput,
-    playersSelect,
-    winnerSelect,
-    notesTextarea,
-    btnSave,
-    btnCancel,
-    loadingRow,
-    errorAlert,
-    dialogContent
+    wrapper, dateInput, playersSelect, winnerSelect, notesTextarea, btnSave, btnCancel, loadingRow,errorAlert, dialogContent
   };
 };
 
@@ -144,10 +135,13 @@ describe("Rendering", () => {
     expect(dialogContent.exists()).toBe(true);
    });
 
-  // TODO: Implement test 1.2
-  it("1.2 - No renderiza cuando modelValue es false", () => {
-    // Verificar que el componente no muestra contenido
-    // O que el dialog no está presente
+  // test 1.2
+  it.only("doesn't render component when modelValue is false", () => {
+    const { dialogContent } = setupAddGameDialogTest({
+      props: { modelValue: false },
+    });
+
+    expect(dialogContent.exists()).toBe(false);
   });
 
   // TODO: Implement test 1.3

--- a/src/components/organisms/AddGameDialog.spec.ts
+++ b/src/components/organisms/AddGameDialog.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, vi, beforeEach, expect } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
+import { setTextInputValue } from "@/tests/utils/form-helpers";
+import AddGameDialog from "@/components/organisms/AddGameDialog.vue";
+import { VDialog, VCard, VSelect, VTextarea, VBtn, VAlert, VRow, VCol } from "vuetify/components";
+import { VDateInput } from "vuetify/labs/VDateInput";
+import { AddGameDialogText } from "@/constants/ui_text/AddGameDialog";
+import type { CollectionsApiResponse } from "@/types/domain/collectionsApi";
+import type { PlayerApiResponse } from "@/types/domain/playerApi";
+
+// Mock composables
+vi.mock("@/composables/usePlayersApi");
+vi.mock("@/composables/useGamesApi");
+
+const vuetify = createVuetifyForTest({
+  VDialog,
+  VCard,
+  VSelect,
+  VDateInput,
+  VTextarea,
+  VBtn,
+  VAlert,
+  VRow,
+  VCol
+});
+
+// Mock data
+const mockBoardgame: CollectionsApiResponse = {
+  id: "game-123",
+  name: "Catan",
+  bgg_id: 333,
+  min_players: 2,
+  max_players: 4,
+  playing_time: 90,
+  complexity: 1.1,
+};
+
+const mockPlayers: PlayerApiResponse[] = [
+  { id: "player-1", name: "Jugador 1", is_registered: true },
+  { id: "player-2", name: "Jugador 2", is_registered: true },
+  { id: "player-3", name: "Jugador 3", is_registered: false },
+];
+
+// Mount function
+const mountAddGameDialog = (options: Record<string, any> = {}) => {
+  return mount(AddGameDialog, {
+    props: {
+      modelValue: true,
+      boardgame: mockBoardgame,
+      ...options.props || {},
+    },
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        "v-dialog": {
+          template: `<div v-bind="$attrs" data-testid="add-game-dialog">
+            <slot/>
+          </div>`,
+          emits: ["update:modelValue"]
+        },
+        "v-date-input": {
+          emits: ["update:modelValue"],
+          props: ["modelValue", "errorMessages", "label"],
+          template: `
+            <div class="v-date-input" :data-testid="$attrs['data-testid']">
+              <input
+                type="date"
+                :value="modelValue"
+                @input="$emit('update:modelValue', $event.target.value)"
+              />
+              <label v-if="label">{{ label }}</label>
+              <div v-if="errorMessages" class="error-message-stub">{{ errorMessages }}</div>
+            </div>
+          `
+        },
+        "v-select": {
+          emits: ["update:modelValue"],
+          props: ["modelValue", "items", "itemTitle", "itemValue", "multiple", "label", "errorMessages", "disabled"],
+          template: `
+            <div class="v-select" :data-testid="$attrs['data-testid']">
+              <label v-if="label">{{ label }}</label>
+              <select
+                :multiple="multiple"
+                :value="modelValue"
+                @change="$emit('update:modelValue', multiple ? Array.from($event.target.selectedOptions, opt => opt.value) : $event.target.value)"
+                :disabled="disabled"
+              >
+                <option v-for="item in items" :key="item[itemValue]" :value="item[itemValue]">
+                  {{ item[itemTitle] }}
+                </option>
+              </select>
+              <div v-if="errorMessages" class="error-message-stub">{{ errorMessages }}</div>
+            </div>
+          `
+        },
+        "v-textarea": {
+          emits: ["update:modelValue"],
+          props: ["modelValue", "errorMessages", "label"],
+          template: `
+            <div class="v-textarea" :data-testid="$attrs['data-testid']">
+              <label v-if="label">{{ label }}</label>
+              <textarea
+                :value="modelValue"
+                @input="$emit('update:modelValue', $event.target.value)"
+              />
+              <div v-if="errorMessages" class="error-message-stub">{{ errorMessages }}</div>
+            </div>
+          `
+        },
+        "v-btn": {
+          emits: ["click"],
+          template: `
+            <button v-bind="$attrs" @click="$emit('click')">
+              <slot/>
+            </button>
+          `
+        },
+        "LoadingRow": {
+          template: `<div data-testid="loading-row">Loading...</div>`
+        }
+      },
+    }
+  });
+};
+
+// Setup function
+const setupAddGameDialogTest = (options: Record<string, any> = {}) => {
+  const wrapper = mountAddGameDialog(options);
+  const dateInput = wrapper.find('[data-testid="date-input"]');
+  const playersSelect = wrapper.find('[data-testid="players-select"]');
+  const winnerSelect = wrapper.find('[data-testid="winner-select"]');
+  const notesTextarea = wrapper.find('[data-testid="notes-textarea"]');
+  const btnSave = wrapper.find('[data-testid="btn-save"]');
+  const btnCancel = wrapper.find('[data-testid="btn-cancel"]');
+  const loadingRow = wrapper.find('[data-testid="loading-row"]');
+  const errorAlert = wrapper.find('[data-testid="error-alert"]');
+  const dialogContent = wrapper.find('[data-testid="add-game-dialog"]');
+
+  return {
+    wrapper,
+    dateInput,
+    playersSelect,
+    winnerSelect,
+    notesTextarea,
+    btnSave,
+    btnCancel,
+    loadingRow,
+    errorAlert,
+    dialogContent
+  };
+};
+
+describe("AddGameDialog - Rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // TODO: Implement test 1.1
+  it("1.1 - Renderiza cuando modelValue es true", () => {
+    // Verificar que el dialog es visible
+    // Verificar que todos los campos están presentes
+  });
+
+  // TODO: Implement test 1.2
+  it("1.2 - No renderiza cuando modelValue es false", () => {
+    // Verificar que el componente no muestra contenido
+    // O que el dialog no está presente
+  });
+
+  // TODO: Implement test 1.3
+  it("1.3 - Muestra loading state", () => {
+    // Verificar que cuando loading=true, muestra LoadingRow
+    // Verificar que oculta el formulario
+  });
+
+  // TODO: Implement test 1.4
+  it("1.4 - Muestra error state (primer intento)", () => {
+    // Verificar que cuando error está presente y errorCount=1
+    // Muestra alerta con mensaje de reintento
+  });
+
+  // TODO: Implement test 1.5
+  it("1.5 - Muestra error state (segundo intento)", () => {
+    // Verificar que cuando errorCount>1
+    // Muestra mensaje de recargar página
+  });
+
+  // TODO: Implement test 1.6
+  it("1.6 - Renderiza todos los campos del formulario", () => {
+    // Verificar que están presentes:
+    // Date input, players select, winner select, notes textarea, botones
+  });
+});

--- a/src/components/organisms/AddGameDialog.vue
+++ b/src/components/organisms/AddGameDialog.vue
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
 import { CollectionsApiResponse } from '../../types/domain/collectionsApi';
 import { usePlayersApi } from '@/composables/usePlayersApi';
-import { useGamesApi } from '@/composables/useGamesApi'; 
+import { useGamesApi } from '@/composables/useGamesApi';
 import { onBeforeMount, ref, type Ref, watch } from 'vue';
 import LoadingRow from '@/components/molecules/LoadingRow.vue';
 import { PlayerApiResponse } from '../../types/domain/playerApi';
@@ -16,16 +16,16 @@ import BlockHeading from '@/components/atoms/typography/BlockHeading.vue';
 import DetailText from '@/components/atoms/typography/DetailText.vue';
 import AppButton from '@/components/atoms/buttons/AppButton.vue';
 
-const props =  defineProps<{
+const props = defineProps<{
   modelValue: boolean,
   boardgame: CollectionsApiResponse | null,
 }>();
 defineOptions({ name: "AddGameDialog" });
 
 const emit = defineEmits<{
-  "update:modelValue": [ dialogVisibility: boolean ],
-  "success": [ message: string],
-  "error": [ message: string ]
+  "update:modelValue": [dialogVisibility: boolean],
+  "success": [message: string],
+  "error": [message: string]
 }>();
 
 const { players, totalPlayers, loading, error, fetchPlayers } = usePlayersApi();
@@ -102,7 +102,7 @@ const { fields, push, remove } = useFieldArray<PlayerInGame>('players');
 watch(selectedPlayers, (newPlayers) => {
   // cleans current array in vee-validate
   // if a player is added and deleted, the array has to be repopulated from scratch
-  while(fields.value.length > 0) {
+  while (fields.value.length > 0) {
     remove(0);
   }
 
@@ -117,7 +117,7 @@ watch(selectedPlayers, (newPlayers) => {
   })
 
   // if the selected winner is no longer in the players array, remove it
-  if(gameWinner.value && !newPlayers.some(p => p.id === gameWinner.value.id)) {
+  if (gameWinner.value && !newPlayers.some(p => p.id === gameWinner.value.id)) {
     gameWinner.value = null;
   }
 
@@ -137,7 +137,7 @@ watch(selectedPlayers, (newPlayers) => {
 
 // WATCH FOR WINNER SELECT
 // checks if the player changes the winner without touching the players
-watch(gameWinner, (newWinner)=> {
+watch(gameWinner, (newWinner) => {
   winnerValue.value = newWinner ? {
     player_id: newWinner.id,
     player_name: newWinner.name,
@@ -146,7 +146,7 @@ watch(gameWinner, (newWinner)=> {
   } : null;
 })
 
-onBeforeMount(async ()=> {
+onBeforeMount(async () => {
   await fetchPlayers();
 })
 
@@ -155,7 +155,7 @@ const closeDialog = () => {
   resetForm();
 
   // reset variables
-  selectedPlayers.value= [];
+  selectedPlayers.value = [];
   gameWinner.value = null;
   errorCount.value = 0;
 
@@ -168,17 +168,17 @@ const closeDialog = () => {
   message instructs the user to reload the page.
 */
 watch(error, (newValue) => {
-  if(newValue !== null) {
+  if (newValue !== null) {
     errorCount.value++;
   }
 })
 
 const handleReloadOnError = async () => {
-  if(errorCount.value === 1) {
+  if (errorCount.value === 1) {
     await fetchPlayers();
 
     // resets errorCount if it loads correctly
-    if(!error.value) {
+    if (!error.value) {
       errorCount.value = 0;
     }
   } else {
@@ -202,28 +202,28 @@ const onSubmit = handleSubmit(async (values) => {
     }))
 
     const formatLocalISODate = (date: Date) => {
-  const offset = -date.getTimezoneOffset();
-  const sign = offset >= 0 ? '+' : '-';
-  const absOffset = Math.abs(offset);
-  const hours = String(Math.floor(absOffset / 60)).padStart(2, '0');
-  const minutes = String(absOffset % 60).padStart(2, '0');
-  const isoDate = date.toISOString().slice(0, 19);
-  return `${isoDate}${sign}${hours}:${minutes}`;
-};
+      const offset = -date.getTimezoneOffset();
+      const sign = offset >= 0 ? '+' : '-';
+      const absOffset = Math.abs(offset);
+      const hours = String(Math.floor(absOffset / 60)).padStart(2, '0');
+      const minutes = String(absOffset % 60).padStart(2, '0');
+      const isoDate = date.toISOString().slice(0, 19);
+      return `${isoDate}${sign}${hours}:${minutes}`;
+    };
 
-const payload: CreateGameRequest = {
-  boardgame_id: props.boardgame.id,
-  // NO ENTIENDO DONDE ESTÁ LA COLLECTION_ID
-  // está hardcodeado en GamesView
-  collection_id: 'b6acc73a-6b7a-4c67-937a-e1a6169f173f',
-  player_group_id: null,
-  start_date: formatLocalISODate(values.date),
-  end_date: formatLocalISODate(new Date(values.date.getTime() + 3600000)),
-  notes: values.notes,
-  players: mappedPlayers,
-};
+    const payload: CreateGameRequest = {
+      boardgame_id: props.boardgame.id,
+      // NO ENTIENDO DONDE ESTÁ LA COLLECTION_ID
+      // está hardcodeado en GamesView
+      collection_id: 'b6acc73a-6b7a-4c67-937a-e1a6169f173f',
+      player_group_id: null,
+      start_date: formatLocalISODate(values.date),
+      end_date: formatLocalISODate(new Date(values.date.getTime() + 3600000)),
+      notes: values.notes,
+      players: mappedPlayers,
+    };
     console.log(payload)
-    
+
     await saveGame(payload);
 
     emit("success", "¡La partida fue guardada exitosamente!");
@@ -237,161 +237,97 @@ const payload: CreateGameRequest = {
 </script>
 
 <template>
-  <v-dialog
-      :model-value="modelValue"
-      @update:model-value="emit('update:modelValue', $event)"
-      max-width="1100px"
-      scrollable
-      data-testid="add-game-dialog"
-    >
+  <v-dialog :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)" max-width="1100px"
+    scrollable data-testid="add-game-dialog">
 
-      <v-card class="dialog">
-        <!-- loading -->
-        <div v-if="loading || error" class="overlay-container">
-          <div class="d-flex flex-column justify-center align-center w-100">
-            <LoadingRow v-if="loading" class="ma-0"></LoadingRow>
+    <v-card class="dialog">
+      <!-- loading -->
+      <div v-if="loading || error" class="overlay-container">
+        <div class="d-flex flex-column justify-center align-center w-100">
+          <LoadingRow data-testid="loading-row" v-if="loading" class="ma-0"></LoadingRow>
 
-            <v-row v-if="error" class="w-66 flex-grow-0">
+          <v-row v-if="error" class="w-66 flex-grow-0">
+            <v-col cols="12">
+              <v-alert data-testid="error-alert" color="error"
+                :title="errorCount === 1 ? AddGameDialogText.errors.failedLoadTitleFirst : AddGameDialogText.errors.failedLoadTitleSecond"
+                class="error-container">
+                <div>
+                  <span class="mt-4">{{ errorCount === 1 ? AddGameDialogText.errors.loadFirstTry :
+                    AddGameDialogText.errors.loadSecondTry }}</span>
+                </div>
+                <template #append>
+                  <v-btn color="white" variant="flat" size="small" @click="handleReloadOnError">
+                    {{ errorCount === 1 ? AddGameDialogText.buttons.retryFirstTry :
+                      AddGameDialogText.buttons.retrySecondTry }}
+                  </v-btn>
+                </template>
+              </v-alert>
+            </v-col>
+          </v-row>
+        </div>
+      </div>
+
+      <div :class="{ 'hidden-on-loading': loading || error }" class="content-wrapper">
+        <v-card-item class="mb-4">
+          <v-card-title class="dialog-title">
+            <BlockHeading>
+              {{ AddGameDialogText.title }}
+            </BlockHeading>
+          </v-card-title>
+          <v-card-subtitle>
+            <DetailText>
+              {{ boardgame.name }}
+            </DetailText>
+          </v-card-subtitle>
+        </v-card-item>
+
+        <v-card-text>
+          <v-form>
+            <v-row>
+              <v-col cols="12" md="4">
+                <v-date-input data-testid="date-input" :label="AddGameDialogText.labels.selectDate" v-model="dateValue"
+                  :error-messages="dateError" prepend-icon="" prepend-inner-icon="$calendar"
+                  variant="outlined"></v-date-input>
+              </v-col>
+              <v-col cols="12" sm="6" md="4">
+                <v-select data-testid="players-select" chips :label="AddGameDialogText.labels.selectPlayers"
+                  :hint="selectedPlayers.length === 0 ? AddGameDialogText.hints.selectPlayers : ''"
+                  v-model="selectedPlayers"
+                  :error-messages="selectedPlayers.length > 0 || submitCount > 0 ? formErrors.players : ''"
+                  :items="players" item-title="name" item-value="id" variant="outlined" density="comfortable" multiple
+                  persistent-hint return-object>
+                </v-select>
+              </v-col>
+              <v-col cols="12" sm="6" md="4">
+                <v-select data-testid="winner-select" chips variant="outlined" density="comfortable"
+                  v-model="gameWinner"
+                  :error-messages="selectedPlayers.length > 0 && (winnerMeta.touched || submitCount > 0) ? winnerError : ''"
+                  :disabled="selectedPlayers.length === 0" :label="AddGameDialogText.labels.selectWinner"
+                  :items="selectedPlayers" item-title="name" item-value="id" return-object></v-select>
+              </v-col>
               <v-col cols="12">
-                <v-alert
-                  color="error"
-                  :title="errorCount === 1 ? AddGameDialogText.errors.failedLoadTitleFirst : AddGameDialogText.errors.failedLoadTitleSecond"
-                  class="error-container"
-                >
-                  <div>
-                      <span class="mt-4">{{ errorCount === 1 ? AddGameDialogText.errors.loadFirstTry : AddGameDialogText.errors.loadSecondTry }}</span>
-                  </div>
-                  <template #append>
-                    <v-btn
-                      color="white"
-                      variant="flat"
-                      size="small"
-                      @click="handleReloadOnError"
-                    >
-                      {{ errorCount === 1 ? AddGameDialogText.buttons.retryFirstTry : AddGameDialogText.buttons.retrySecondTry }}
-                    </v-btn>
-                  </template>
-                </v-alert>
+                <v-textarea data-testid="notes-textarea" variant="outlined" v-model="notesValue"
+                  :error-messages="notesError" :label="AddGameDialogText.labels.notes" no-resize
+                  max-rows="3"></v-textarea>
               </v-col>
             </v-row>
-          </div>
-        </div>
+          </v-form>
+        </v-card-text>
 
-        <div :class="{ 'hidden-on-loading': loading || error }" class="content-wrapper">
-          <v-card-item class="mb-4" >
-            <v-card-title class="dialog-title">
-              <BlockHeading>
-                {{ AddGameDialogText.title }}
-              </BlockHeading>
-            </v-card-title>
-            <v-card-subtitle>
-              <DetailText>
-                {{ boardgame.name }}
-              </DetailText>
-            </v-card-subtitle>
-          </v-card-item>
-           
-          <v-card-text>
-            <v-form>
-              <v-row>
-                <v-col
-                  cols="12"
-                  md="4"
-                >
-                  <v-date-input
-                    :label="AddGameDialogText.labels.selectDate"
-                    v-model="dateValue"
-                    :error-messages="dateError"
-                    prepend-icon=""
-                    prepend-inner-icon="$calendar"
-                    variant="outlined"
-                  ></v-date-input>
-                </v-col>
-                <v-col
-                  cols="12"
-                  sm="6"
-                  md="4"  
-                >
-                  <v-select
-                    chips
-                    :label="AddGameDialogText.labels.selectPlayers"
-                    :hint="selectedPlayers.length === 0 ? AddGameDialogText.hints.selectPlayers : ''"
-                    v-model="selectedPlayers"
-                    :error-messages="selectedPlayers.length > 0 || submitCount > 0 ? formErrors.players : ''"
-                    :items="players"
-                    item-title="name"
-                    item-value="id"
-                    variant="outlined"
-                    density="comfortable"
-                    multiple
-                    persistent-hint
-                    return-object
-                  >
-                  </v-select>
-                </v-col>
-                <v-col
-                  cols="12"
-                  sm="6"
-                  md="4"
-                >
-                  <v-select
-                    chips
-                    variant="outlined"
-                    density="comfortable"
-                    v-model="gameWinner"
-                    :error-messages="selectedPlayers.length > 0 && (winnerMeta.touched || submitCount > 0) ? winnerError : ''"
-                    :disabled="selectedPlayers.length === 0"
-                    :label="AddGameDialogText.labels.selectWinner"
-                    :items="selectedPlayers"
-                    item-title="name"
-                    item-value="id"
-                    return-object
-                  ></v-select>
-                </v-col>
-                <v-col
-                  cols="12"
-                >
-                  <v-textarea
-                    variant="outlined"
-                    v-model="notesValue"
-                    :error-messages="notesError"
-                    :label="AddGameDialogText.labels.notes"
-                    no-resize
-                    max-rows="3"
-                  ></v-textarea>
-                </v-col>
-              </v-row>
-            </v-form>
-          </v-card-text>
-  
-          <v-card-actions class="dialog-actions mt-3">
-            <AppButton
-              class="dialog-button"
-              type="submit"
-              @click="onSubmit"
-              color="primary"
-              variant="flat"
-              density="default"
-              :loading="savingGame"
-              :icon="faFloppyDisk"
-              :label="AddGameDialogText.buttons.save"
-            />
-            <AppButton
-              class="dialog-button"
-              color="error"
-              variant="text"
-              density="default"
-              @click="closeDialog"
-              :label="AddGameDialogText.buttons.cancel"
-            />
-          </v-card-actions>
-        </div>
-      </v-card>
-    </v-dialog>
+        <v-card-actions class="dialog-actions mt-3">
+          <AppButton data-testid="btn-save" class="dialog-button" type="submit" @click="onSubmit" color="primary"
+            variant="flat" density="default" :loading="savingGame" :icon="faFloppyDisk"
+            :label="AddGameDialogText.buttons.save" />
+          <AppButton data-testid="btn-cancel" class="dialog-button" color="error" variant="text" density="default"
+            @click="closeDialog" :label="AddGameDialogText.buttons.cancel" />
+        </v-card-actions>
+      </div>
+    </v-card>
+  </v-dialog>
 </template>
 
 <style scoped>
-.dialog{
+.dialog {
   position: relative !important;
   padding: 12px;
   display: flex;

--- a/src/components/organisms/AddGameDialog.vue
+++ b/src/components/organisms/AddGameDialog.vue
@@ -110,6 +110,7 @@ watch(selectedPlayers, (newPlayers) => {
   newPlayers.forEach((player) => {
     push({
       player_id: player.id,
+      player_name: player.name,
       is_winner: gameWinner.value?.id === player.id,
       is_registered: player.is_registered ?? false,
     })
@@ -125,6 +126,7 @@ watch(selectedPlayers, (newPlayers) => {
   // if there is a winner, we send the object formated to schema
   winnerValue.value = gameWinner.value ? {
     player_id: gameWinner.value.id,
+    player_name: gameWinner.value.name,
     is_winner: true,
     is_registered: gameWinner.value.is_registered ?? false,
   } : null;
@@ -138,6 +140,7 @@ watch(selectedPlayers, (newPlayers) => {
 watch(gameWinner, (newWinner)=> {
   winnerValue.value = newWinner ? {
     player_id: newWinner.id,
+    player_name: newWinner.name,
     is_winner: true,
     is_registered: newWinner.is_registered ?? false,
   } : null;
@@ -193,7 +196,9 @@ const onSubmit = handleSubmit(async (values) => {
     // it was showing all players as winner false
     const mappedPlayers = values.players.map((player) => ({
       player_id: player.player_id,
+      player_name: player.player_name,
       is_winner: player.player_id === gameWinner.value?.id,
+      is_registered: player.is_registered ?? false,
     }))
 
     const formatLocalISODate = (date: Date) => {

--- a/test-add-game-dialog.md
+++ b/test-add-game-dialog.md
@@ -1,0 +1,243 @@
+# Plan de Testing: AddGameDialog.vue
+
+## Introducción
+
+AddGameDialog es un componente crítico que maneja el guardado de partidas (la funcionalidad principal de la app). Es un modal (v-dialog) que contiene un formulario complejo con validaciones de VeeValidate + Yup.
+
+## ¿Por qué es difícil testear este componente?
+
+1. **Es un modal (v-dialog)**: Los modales de Vuetify controlan su visibilidad internamente y manejan el focus, portal, y eventos de teclado. No podemos simplemente montar el componente y esperar que sea visible.
+
+2. **Usa composables que hacen llamadas API**: `usePlayersApi` y `useGamesApi` llaman a APIs reales o mockeadas.
+
+3. **VeeValidate con Yup**: Las validaciones ocurren de forma asíncrona y necesitan que el formulario esté montado correctamente.
+
+4. **Componentes de Vuetify**: v-date-input, v-select (múltiple), v-textarea tienen comportamientos complejos.
+
+## Estrategia de Testing
+
+### 1. Stubbing de Vuetify Dialog
+Al igual que `AddPlayerSheet.spec.ts` hace stub de `v-bottom-sheet`, debemos hacer stub de `v-dialog` para que simplemente renderice su contenido sin la lógica de modal.
+
+```typescript
+stubs: {
+  "v-dialog": {
+    template: `<div v-bind="$attrs" data-testid="add-game-dialog">
+      <slot/>
+    </div>`,
+    emits: ["update:modelValue"]
+  }
+}
+```
+
+### 2. Mocking de Composables
+Usar `vi.mock()` o mockear retornos de los composables para controlar:
+- `usePlayersApi`: Mock de `players`, `loading`, `error`, `fetchPlayers`
+- `useGamesApi`: Mock de `saveGame`, `loading`, `errorSaveGame`, `newGame`
+
+### 3. Data-testid Attributes
+El componente ya tiene `data-testid="add-game-dialog"`. Necesitamos agregar más para testear:
+- `data-testid="date-input"` en v-date-input
+- `data-testid="players-select"` en el v-select de jugadores
+- `data-testid="winner-select"` en el v-select de ganador
+- `data-testid="notes-textarea"` en v-textarea
+- `data-testid="btn-save"` en el botón guardar
+- `data-testid="btn-cancel"` en el botón cancelar
+- `data-testid="loading-row"` para el LoadingRow
+- `data-testid="error-alert"` para la alerta de error
+
+## Tests Necesarios
+
+### Grupo 1: Rendering (Renderizado)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 1.1 | Renderiza cuando modelValue es true | El dialog es visible, todos los campos están presentes |
+| 1.2 | No renderiza cuando modelValue es false | El componente no muestra contenido (o el dialog no está) |
+| 1.3 | Muestra loading state | Cuando `loading=true`, muestra LoadingRow, oculta formulario |
+| 1.4 | Muestra error state (primer intento) | Cuando `error` está presente y `errorCount=1`, muestra alerta con mensaje de reintento |
+| 1.5 | Muestra error state (segundo intento) | Cuando `errorCount>1`, muestra mensaje de recargar página |
+| 1.6 | Renderiza todos los campos del formulario | Date input, players select, winner select, notes textarea, botones |
+
+### Grupo 2: Player Loading (Carga de Jugadores)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 2.1 | Llama a fetchPlayers en onBeforeMount | El mock de fetchPlayers fue llamado una vez |
+| 2.2 | Muestra loading mientras carga jugadores | LoadingRow visible, formulario oculto |
+| 2.3 | Popula el select de jugadores con los datos recibidos | El v-select tiene las opciones correctas |
+| 2.4 | Maneja error al cargar jugadores | Muestra alerta de error, botón de reintento |
+
+### Grupo 3: Form Interactions (Interacciones del Formulario)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 3.1 | Seleccionar fecha | `dateValue` se actualiza correctamente |
+| 3.2 | Seleccionar jugadores (múltiple) | `selectedPlayers` se actualiza, el array de jugadores en el form se actualiza |
+| 3.3 | Seleccionar ganador | `gameWinner` se actualiza, solo disponible si hay jugadores seleccionados |
+| 3.4 | Escribir notas | `notesValue` se actualiza |
+| 3.5 | Ganador se deselecciona si se quita el jugador | Si quitas un jugador que era ganador, `gameWinner` vuelve a null |
+
+### Grupo 4: Form Validations (Validaciones)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 4.1 | Fecha es requerida | Error message aparece si no hay fecha |
+| 4.2 | Fecha no puede ser futura | Error message si la fecha es mayor a hoy |
+| 4.3 | Debe seleccionar al menos min_players | Error si selecciona menos jugadores que el mínimo del juego |
+| 4.4 | No puede seleccionar más de max_players | Error si selecciona más jugadores que el máximo |
+| 4.5 | Ganador es requerido | Error si no selecciona ganador y tocó el campo |
+| 4.6 | Notas tienen máximo 500 caracteres | Error si excede el límite |
+| 4.7 | Formato correcto de payload al hacer submit | Los jugadores tienen `player_id` e `is_winner` correctos |
+
+### Grupo 5: Form Submission (Envío del Formulario)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 5.1 | Envío exitoso | Llama a `saveGame`, emite `success`, cierra dialog |
+| 5.2 | Error al guardar (400) | Emite `error` con mensaje correcto, no cierra dialog |
+| 5.3 | Error al guardar (500) | Emite `error` con mensaje correcto, no cierra dialog |
+| 5.4 | Error de red | Emite `error` con mensaje de red |
+| 5.5 | Loading state durante guardado | `savingGame` es true mientras guarda |
+
+### Grupo 6: Dialog Closure (Cierre del Dialog)
+
+| Test | Descripción | Qué verificar |
+|------|-------------|---------------|
+| 6.1 | Click en Cancelar | Emite `update:modelValue` con false, resetea formulario |
+| 6.2 | Guardado exitoso cierra dialog | Después de success, el dialog se cierra |
+| 6.3 | Resetea formulario al cerrar | `selectedPlayers`, `gameWinner`, `errorCount` vuelven a valores iniciales |
+
+## Estructura del Archivo de Test
+
+```typescript
+import { describe, it, vi, beforeEach, afterEach, expect } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { createVuetifyForTest } from "@/tests/utils/createVuetifyForTest";
+import { setTextInputValue } from "@/tests/utils/form-helpers";
+import AddGameDialog from "@/components/organisms/AddGameDialog.vue";
+import { VDialog, VCard, VSelect, VDateInput, VTextarea, VBtn } from "vuetify/components";
+
+// Mocks
+vi.mock("@/composables/usePlayersApi");
+vi.mock("@/composables/useGamesApi");
+
+const vuetify = createVuetifyForTest({ 
+  VDialog, VCard, VSelect, VDateInput, VTextarea, VBtn 
+});
+
+describe("AddGameDialog", () => {
+  describe("Rendering", () => { /* tests */ });
+  describe("Player Loading", () => { /* tests */ });
+  describe("Form Interactions", () => { /* tests */ });
+  describe("Form Validations", () => { /* tests */ });
+  describe("Form Submission", () => { /* tests */ });
+  describe("Dialog Closure", () => { /* tests */ });
+});
+```
+
+## Cómo hacer los tests paso a paso
+
+### Paso 1: Configurar el mount con stubs adecuados
+
+```typescript
+const mountAddGameDialog = (props = {}, mocks = {}) => {
+  return mount(AddGameDialog, {
+    props: {
+      modelValue: true,
+      boardgame: {
+        id: "game-123",
+        name: "Catan",
+        min_players: 2,
+        max_players: 4,
+        // ... otras props necesarias
+      },
+      ...props
+    },
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        "v-dialog": {
+          template: `<div v-bind="$attrs" data-testid="add-game-dialog">
+            <slot/>
+          </div>`,
+          emits: ["update:modelValue"]
+        },
+        // Stub otros componentes de Vuetify según necesidad
+      }
+    }
+  });
+};
+```
+
+### Paso 2: Mock de composables antes de cada test
+
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks();
+  
+  // Mock usePlayersApi
+  (usePlayersApi as vi.Mock).mockReturnValue({
+    players: ref(mockPlayers),
+    loading: ref(false),
+    error: ref(null),
+    fetchPlayers: vi.fn().mockResolvedValue(undefined)
+  });
+  
+  // Mock useGamesApi
+  (useGamesApi as vi.Mock).mockReturnValue({
+    saveGame: vi.fn().mockResolvedValue(mockGameResponse),
+    loading: ref(false),
+    errorSaveGame: ref(null),
+    newGame: ref(null)
+  });
+});
+```
+
+### Paso 3: Para tests de formulario, interactuar así
+
+```typescript
+// Para v-select (jugadores)
+await wrapper.find('[data-testid="players-select"]').setValue([player1, player2]);
+
+// Para v-select (ganador)  
+await wrapper.find('[data-testid="winner-select"]').setValue(player1);
+
+// Para date-input, puede requerir simular el evento de cambio
+// O usar setTextInputValue si tiene un input interno
+
+// Para textarea
+await setTextInputValue(wrapper, "notes-textarea", "Notas de prueba");
+
+// Para hacer submit
+await wrapper.find('[data-testid="btn-save"]').trigger("click");
+```
+
+### Paso 4: Verificar eventos emitidos
+
+```typescript
+expect(wrapper.emitted("success")).toBeTruthy();
+expect(wrapper.emitted("success")[0]).toEqual(["¡La partida fue guardada exitosamente!"]);
+
+expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+expect(wrapper.emitted("update:modelValue")[0]).toEqual([false]);
+```
+
+## Consejos importantes
+
+1. **usa `await nextTick()` después de cada interacción** para asegurar que Vue procese los cambios reactivos.
+
+2. **Para VeeValidate**, las validaciones pueden ser asíncronas. Usa `await wrapper.vm.handleSubmit()` o asegúrate de que el formulario esté validado antes de verificar errores.
+
+3. **El stub de v-dialog es clave**: Sin esto, el modal puede no renderizar su contenido en el test porque Vuetify controla la visibilidad con portal.
+
+4. **Mock de fecha**: Si el test usa fechas, mock de `new Date()` para tener consistencia:
+```typescript
+const mockDate = new Date("2026-05-06");
+vi.spyOn(global, "Date").mockImplementation(() => mockDate);
+```
+
+5. **Para v-select múltiple**, el modelo es un array. Asegúrate de pasar arrays al hacer `setValue`.
+
+6. **Verificar mensajes de error**: Usa `wrapper.html()` para ver el HTML renderizado y verificar que el mensaje de error esté presente.


### PR DESCRIPTION
La idea original era hacer los tests de AddGameDialog para después refactorizarlo para que pueda guardar y editar partidas. 
Trabajando con IA para testear este componente ya empezó a tener problemas con los tests sencillos de renderizado. AddGameDialog usa un v-dialog, lo que dificulta considerablemente testear los elementos dentro del dialog porque Vuetify no los guarda en el DOM.

Incorporo los tests de renderizado que ya hice porque existen. Pero el plan de refactorizado para poder hacer ambas cosas en un mismo componente queda abandonado. Sería perder una enorme cantidad de tiempo en algo que puede no funcionar directamente. La alternativa de duplicar el componente y modificarlo para que permita editar permite avanzar con la aplicación, que es lo más importante. 

Closes #154, Closes #128