### PR TITLE
Feature: Agregar vista NotFound para rutas inexistentes

### DIFF
--- a/src/components/atoms/buttons/AppButton.vue
+++ b/src/components/atoms/buttons/AppButton.vue
@@ -8,7 +8,8 @@ interface Props {
   density?: "compact" | "comfortable" | "default",
   size?: "x-small" | "small" | undefined| "large" | "x-large",
   icon?: any,
-  label: string
+  label: string,
+  to?: any,
 }
 
 const props = withDefaults(defineProps<Props>(),{
@@ -22,6 +23,7 @@ const props = withDefaults(defineProps<Props>(),{
 <template>
   <v-btn
     v-bind="$attrs"
+    :to="to"
     :color="color"
     :variant="variant"
     :density="density"
@@ -36,7 +38,3 @@ const props = withDefaults(defineProps<Props>(),{
     <slot></slot>
   </v-btn>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/constants/documentTitles.ts
+++ b/src/constants/documentTitles.ts
@@ -1,5 +1,6 @@
 export const DOCUMENT_TITLES = {
   BOARDGAMES: "Ludoteca - BGT",
   PLAYERS: "Jugadores - BGT",
-  GAMES: "Partidas - BGT"
+  GAMES: "Partidas - BGT",
+  NOT_FOUND: "Página no encontrada - BGT"
 }

--- a/src/constants/ui_text/NotFound.ts
+++ b/src/constants/ui_text/NotFound.ts
@@ -2,5 +2,5 @@ export const NOT_FOUND = {
   TITLE: "¡Oh,no!",
   TEXT_1: "La página que estás buscando no está disponible o no existe.",
   TEXT_2: "Como diría Alejandro Lerner, es momento de volver a empezar.",
-  BTN_TEXT: "Volver al inicio"
+  BTN_TEXT: "Volver a la ludoteca"
 }

--- a/src/constants/ui_text/NotFound.ts
+++ b/src/constants/ui_text/NotFound.ts
@@ -1,0 +1,6 @@
+export const NOT_FOUND = {
+  TITLE: "¡Oh,no!",
+  TEXT_1: "La página que estás buscando no está disponible o no existe.",
+  TEXT_2: "Como diría Alejandro Lerner, es momento de volver a empezar.",
+  BTN_TEXT: "Volver al inicio"
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,11 @@ export const routes: RouteRecordRaw[] = [
     path: "/tipografia",
     name: "Typography",
     component: () => import(/*webpackChunkName: "Tipografia" */"@/views/Typography.vue"),
+  },
+  {
+    path: "/:catchAll(.*)*",
+    name: "Not-Found",
+    component: () => import(/*webpackChunkName: "Not-Found" */"@/views/NotFound.vue"),
   }
 ];
 

--- a/src/views/BoardGames/BoardGamesView.vue
+++ b/src/views/BoardGames/BoardGamesView.vue
@@ -47,7 +47,11 @@ onBeforeMount(async () => {
 
 <template>
   <v-container class="my-4 my-md-6 my-lg-8">
-    <DisplayTitle>Ludoteca</DisplayTitle>
+    <v-row>
+      <v-col>
+        <DisplayTitle>Ludoteca</DisplayTitle>
+      </v-col>
+    </v-row>
 
     <!-- error on the boardgames list initial fetch -->
     <v-row v-if="errorFetchCollections">

--- a/src/views/Games/GamesView.vue
+++ b/src/views/Games/GamesView.vue
@@ -30,7 +30,11 @@ const onPageChange = async () => {
 
 <template>
   <v-container class="my-4 my-md-6 my-lg-8">
-    <DisplayTitle>Partidas</DisplayTitle>
+    <v-row>
+      <v-col>
+        <DisplayTitle>Partidas</DisplayTitle>
+      </v-col>
+    </v-row>
 
     <!-- error on games initial fetch -->
     <v-row v-if="errorGetGames">

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <h1>Not found</h1>
+</template>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -16,6 +16,7 @@ import { NOT_FOUND } from '@/constants/ui_text/NotFound';
         </div>
         <AppButton
           size="large"
+          :to="{ name: 'BoardGames' }"
           :label="NOT_FOUND.BTN_TEXT"
         />
       </v-col>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,5 +1,24 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import DisplayTitle from '@/components/atoms/typography/DisplayTitle.vue';
+import LeadText from '@/components/atoms/typography/LeadText.vue';
+import AppButton from '@/components/atoms/buttons/AppButton.vue';
+import { NOT_FOUND } from '@/constants/ui_text/NotFound';
+</script>
 
 <template>
-  <h1>Not found</h1>
+  <v-container class="my-4 my-md-6 my-lg-8">
+    <v-row>
+      <v-col>
+        <DisplayTitle>{{ NOT_FOUND.TITLE }}</DisplayTitle>
+        <div class="mb-6">
+          <LeadText>{{ NOT_FOUND.TEXT_1 }}</LeadText>
+          <LeadText>{{ NOT_FOUND.TEXT_2 }}</LeadText>
+        </div>
+        <AppButton
+          size="large"
+          :label="NOT_FOUND.BTN_TEXT"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -2,7 +2,13 @@
 import DisplayTitle from '@/components/atoms/typography/DisplayTitle.vue';
 import LeadText from '@/components/atoms/typography/LeadText.vue';
 import AppButton from '@/components/atoms/buttons/AppButton.vue';
+import { useDocumentTitle } from '@/composables/useDocumentTitle';
 import { NOT_FOUND } from '@/constants/ui_text/NotFound';
+import { DOCUMENT_TITLES } from '@/constants/documentTitles';
+
+defineOptions({ name: "NotFound" });
+
+useDocumentTitle(DOCUMENT_TITLES.NOT_FOUND);
 
 </script>
 

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -3,6 +3,7 @@ import DisplayTitle from '@/components/atoms/typography/DisplayTitle.vue';
 import LeadText from '@/components/atoms/typography/LeadText.vue';
 import AppButton from '@/components/atoms/buttons/AppButton.vue';
 import { NOT_FOUND } from '@/constants/ui_text/NotFound';
+
 </script>
 
 <template>


### PR DESCRIPTION
### Cambios realizados
- Creada la vista NotFound para manejar los casos donde el usuario ingresa una ruta no existente en la app. Esta vista muestra mensaje de página no existente y redirige al inicio.
- Refactor de AppButton para que reciba la props to opcionalmente y se pueda usar para navegación.
- Refactor de GamesView y BoardGamesView, el título de las páginas no tenía su propio row.


Closes #201 